### PR TITLE
Tech embassy fix attendees table

### DIFF
--- a/backend/modules/email-task/routes.js
+++ b/backend/modules/email-task/routes.js
@@ -16,14 +16,27 @@ const messageParams = () =>
         subject: Joi.string()
             .max(200)
             .required(),
+        body: Joi.string().required(),
         subtitle: Joi.string()
             .max(200)
-            .required(),
-        header_image: Joi.string().uri(),
-        body: Joi.string(),
-        cta_text: Joi.string().max(100),
-        cta_link: Joi.string().uri(),
-        reply_to: Joi.string().email(),
+            .optional()
+            .allow(''),
+        header_image: Joi.string()
+            .uri()
+            .optional()
+            .allow(''),
+        cta_text: Joi.string()
+            .max(100)
+            .optional()
+            .allow(''),
+        cta_link: Joi.string()
+            .uri()
+            .optional()
+            .allow(''),
+        reply_to: Joi.string()
+            .email()
+            .optional()
+            .allow(''),
     })
 
 router
@@ -54,7 +67,9 @@ router.route('/:slug/send').post(
                 .min(1)
                 .required(),
             params: messageParams(),
-            uniqueId: Joi.string(),
+            uniqueId: Joi.string()
+                .optional()
+                .allow(''),
         },
     }),
     hasToken,

--- a/backend/modules/email-task/routes.js
+++ b/backend/modules/email-task/routes.js
@@ -50,7 +50,7 @@ router.route('/:slug/send').post(
     celebrate({
         body: {
             recipients: Joi.array()
-                .items(Joi.string().email())
+                .items(Joi.string())
                 .min(1)
                 .required(),
             params: messageParams(),

--- a/backend/modules/registration/controller.js
+++ b/backend/modules/registration/controller.js
@@ -287,7 +287,7 @@ controller.assignRegistrationForEvent = data => {
     })
 }
 
-controller.bulkEditRegistrations = (eventId, registrationIds, edits) => {
+controller.bulkEditRegistrations = (eventId, userIds, edits) => {
     const cleanedEdits = _.pick(edits, [
         'status',
         'tags',
@@ -298,7 +298,7 @@ controller.bulkEditRegistrations = (eventId, registrationIds, edits) => {
     return Registration.find({
         event: eventId,
         user: {
-            $in: registrationIds,
+            $in: userIds,
         },
     }).then(registrations => {
         const updates = registrations

--- a/backend/modules/registration/routes.js
+++ b/backend/modules/registration/routes.js
@@ -32,7 +32,6 @@ const getRegistration = asyncHandler(async (req, res) => {
 })
 
 const createRegistration = asyncHandler(async (req, res) => {
-    console.log('CREATING REGISTRATION')
     const registration = await RegistrationController.createRegistration(
         req.user,
         req.event,
@@ -145,7 +144,7 @@ const getFullRegistration = asyncHandler(async (req, res) => {
 const bulkEditRegistrations = asyncHandler(async (req, res) => {
     await RegistrationController.bulkEditRegistrations(
         req.event._id.toString(),
-        req.body.registrationIds,
+        req.body.userIds,
         req.body.edits
     )
     return res.status(200).json([])

--- a/frontend/src/components/modals/BulkEditRegistrationModal/index.js
+++ b/frontend/src/components/modals/BulkEditRegistrationModal/index.js
@@ -27,7 +27,7 @@ import * as OrganiserActions from 'redux/organiser/actions'
 import * as SnackbarActions from 'redux/snackbar/actions'
 import { useFormField } from 'hooks/formHooks'
 
-export default ({ visible, registrationIds = [], onClose }) => {
+export default ({ visible, userIds = [], onClose }) => {
     const dispatch = useDispatch()
     const event = useSelector(OrganiserSelectors.event)
     const [loading, setLoading] = useState(false)
@@ -83,16 +83,12 @@ export default ({ visible, registrationIds = [], onClose }) => {
         const edits = getEdits()
 
         dispatch(
-            OrganiserActions.bulkEditRegistrations(
-                registrationIds,
-                edits,
-                event.slug
-            )
+            OrganiserActions.bulkEditRegistrations(userIds, edits, event.slug)
         )
             .then(() => {
                 dispatch(
                     SnackbarActions.success(
-                        `Edited ${registrationIds.length} registrations`
+                        `Edited ${userIds.length} registrations`
                     )
                 )
             })
@@ -103,9 +99,9 @@ export default ({ visible, registrationIds = [], onClose }) => {
                 setLoading(false)
                 handleClose()
             })
-    }, [getEdits, registrationIds, event.slug, dispatch, handleClose])
+    }, [getEdits, dispatch, userIds, event.slug, handleClose])
 
-    if (!registrationIds.length) return null
+    if (!userIds.length) return null
     return (
         <Dialog fullScreen open={visible} onClose={handleClose}>
             <PageWrapper loading={loading} wrapContent={false}>
@@ -113,7 +109,7 @@ export default ({ visible, registrationIds = [], onClose }) => {
                     <ConfirmDialog
                         open={confirmDialog}
                         title="Are you sure?"
-                        message={`This will apply your configured changes to ${registrationIds.length} registrations, and you won't be able to revert them. Please make sure you are not making any unintended changes.`}
+                        message={`This will apply your configured changes to ${userIds.length} registrations, and you won't be able to revert them. Please make sure you are not making any unintended changes.`}
                         onClose={() => setConfirmDialog(false)}
                         onOk={handleSubmit}
                     />
@@ -121,8 +117,7 @@ export default ({ visible, registrationIds = [], onClose }) => {
                         <PageHeader
                             heading="Bulk edit"
                             subheading={
-                                registrationIds.length +
-                                ' selected participants'
+                                userIds.length + ' selected participants'
                             }
                         />
                         <Typography variant="body1" paragraph>
@@ -327,7 +322,7 @@ export default ({ visible, registrationIds = [], onClose }) => {
                     >
                         {expandedIds.length === 0
                             ? 'Expand panels to make edits'
-                            : ` Apply edits to ${registrationIds.length} registrations`}
+                            : ` Apply edits to ${userIds.length} registrations`}
                     </Button>
                 </DialogActions>
             </PageWrapper>

--- a/frontend/src/components/modals/BulkEmailModal/index.js
+++ b/frontend/src/components/modals/BulkEmailModal/index.js
@@ -24,7 +24,7 @@ import * as SnackbarActions from 'redux/snackbar/actions'
 import { useFormField } from 'hooks/formHooks'
 import EmailService from 'services/email'
 
-export default ({ visible, registrationIds = [], onClose }) => {
+export default ({ visible, userIds = [], onClose }) => {
     const dispatch = useDispatch()
     const idToken = useSelector(AuthSelectors.getIdToken)
     const user = useSelector(UserSelectors.userProfile)
@@ -133,14 +133,14 @@ export default ({ visible, registrationIds = [], onClose }) => {
         EmailService.sendBulkEmail(
             idToken,
             event.slug,
-            registrationIds,
+            userIds,
             params,
             messageId.value
         )
             .then(data => {
                 dispatch(
                     SnackbarActions.success(
-                        `Email sent to ${registrationIds.length} recipients`,
+                        `Email sent to ${userIds.length} recipients`,
                         { autoHideDuration: 5000 }
                     )
                 )
@@ -156,14 +156,14 @@ export default ({ visible, registrationIds = [], onClose }) => {
         validate,
         idToken,
         event.slug,
-        registrationIds,
+        userIds,
         params,
         messageId.value,
         dispatch,
         onClose,
     ])
 
-    if (!registrationIds.length) return null
+    if (!userIds.length) return null
 
     return (
         <Dialog fullScreen open={visible} onClose={onClose}>
@@ -173,15 +173,14 @@ export default ({ visible, registrationIds = [], onClose }) => {
                         <ConfirmDialog
                             open={confirmModalOpen}
                             title="Are you sure?"
-                            message={`This will send an email to ${registrationIds.length} recipient(s). If you haven't yet, please send the email to yourself and make sure it looks like you want.`}
+                            message={`This will send an email to ${userIds.length} recipient(s). If you haven't yet, please send the email to yourself and make sure it looks like you want.`}
                             onClose={setConfirmModalOpen}
                             onOk={handleConfirm}
                         />
                         <PageHeader
                             heading="Bulk email"
                             subheading={
-                                registrationIds.length +
-                                ' selected participants'
+                                userIds.length + ' selected participants'
                             }
                         />
                         <Typography variant="body1" paragraph>
@@ -275,7 +274,7 @@ export default ({ visible, registrationIds = [], onClose }) => {
                     color="primary"
                     onClick={setConfirmModalOpen}
                 >
-                    Send to {registrationIds.length} recipients
+                    Send to {userIds.length} recipients
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/tables/AttendeeTable/index.js
+++ b/frontend/src/components/tables/AttendeeTable/index.js
@@ -196,12 +196,12 @@ export default ({
             <BulkEditRegistrationModal
                 visible={activeModal === 'bulkEdit'}
                 onClose={resetSearch}
-                registrationIds={selected.map(s => s.original.user)}
+                userIds={selected.map(s => s.original.user)}
             />
             <BulkEmailModal
                 visible={activeModal === 'bulkEmail'}
                 onClose={resetSearch}
-                registrationIds={selected.map(s => s.original.user)}
+                userIds={selected.map(s => s.original.user)}
             />
             <Table
                 data={attendees}

--- a/frontend/src/components/tables/AttendeeTable/index.js
+++ b/frontend/src/components/tables/AttendeeTable/index.js
@@ -196,12 +196,12 @@ export default ({
             <BulkEditRegistrationModal
                 visible={activeModal === 'bulkEdit'}
                 onClose={resetSearch}
-                registrationIds={selected}
+                registrationIds={selected.map(s => s.original.user)}
             />
             <BulkEmailModal
                 visible={activeModal === 'bulkEmail'}
                 onClose={resetSearch}
-                registrationIds={selected}
+                registrationIds={selected.map(s => s.original.user)}
             />
             <Table
                 data={attendees}

--- a/frontend/src/redux/organiser/actions.js
+++ b/frontend/src/redux/organiser/actions.js
@@ -165,7 +165,7 @@ export const updateRegistrationTravelGrant = (
     return registration
 }
 
-export const bulkEditRegistrations = (registrationIds, edits, slug) => async (
+export const bulkEditRegistrations = (userIds, edits, slug) => async (
     dispatch,
     getState
 ) => {
@@ -174,7 +174,7 @@ export const bulkEditRegistrations = (registrationIds, edits, slug) => async (
     await RegistrationsService.bulkEditRegistrationsForEvent(
         idToken,
         slug,
-        registrationIds,
+        userIds,
         edits
     )
 

--- a/frontend/src/services/email.js
+++ b/frontend/src/services/email.js
@@ -27,6 +27,8 @@ EmailService.sendBulkEmail = (idToken, slug, recipients, params, uniqueId) => {
         uniqueId,
     }
 
+    console.log('DATA', data)
+
     return _axios.post(`${BASE_ROUTE}/${slug}/send`, data, config(idToken))
 }
 

--- a/frontend/src/services/email.js
+++ b/frontend/src/services/email.js
@@ -27,8 +27,6 @@ EmailService.sendBulkEmail = (idToken, slug, recipients, params, uniqueId) => {
         uniqueId,
     }
 
-    console.log('DATA', data)
-
     return _axios.post(`${BASE_ROUTE}/${slug}/send`, data, config(idToken))
 }
 

--- a/frontend/src/services/registrations.js
+++ b/frontend/src/services/registrations.js
@@ -67,12 +67,12 @@ RegistrationsService.getRegistrationsForEvent = (idToken, slug) => {
 RegistrationsService.bulkEditRegistrationsForEvent = (
     idToken,
     slug,
-    registrationIds,
+    userIds,
     edits
 ) => {
     return _axios.patch(
         `${BASE_ROUTE}/${slug}/bulk`,
-        { registrationIds, edits },
+        { userIds, edits },
         config(idToken)
     )
 }


### PR DESCRIPTION
#42 , complemented with the fixes from this comment

> Yep, it does seem that the naming is wrong - the route currently uses the userId, not the registrationId. While we're fixing the bug, it would make sense to change the naming accordingly. Could you follow the api route to the backend and change the variable names everywhere from registrationIds to userIds?

Also upon testing this out it seems that the bulk email parameter validation wasn't quite working properly, so I went ahead and fixed that too. 