### PR TITLE
fix/change-register-text Changed 'Login to register' to 'Apply now'

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -40,7 +40,7 @@
     "Edit_registration_": "Edit your registration",
     "Event_dashboard_": "Event dashboard",
     "Register_now_": "Register now",
-    "Log_in_register_": "Log in to register",
+    "Log_in_register_": "Apply now",
     "Period_ended_": "The application period for this event has ended!",
     "Log_in_": "Log in",
     "Applications_begins_": "The application period begins {{time}}",


### PR DESCRIPTION
Can be merged instantly, only changed `translation.json`