### PR TITLE
Hotfix - Fixed profile image size to cover the container given

### DIFF
--- a/frontend/src/components/Participant/ParticipantPreview/index.js
+++ b/frontend/src/components/Participant/ParticipantPreview/index.js
@@ -47,7 +47,7 @@ export default ({
             className={`tw-flex tw-gap-4 tw-h- tw-rounded-lg ${styling.borderStyle} ${styling.alignment}`}
         >
             <div
-                className={`tw-bg-gradient-to-r tw-from-teal-400 tw-to-blue-500 tw-rounded-full ${styling.imageSize}`}
+                className={`tw-bg-gradient-to-r tw-from-teal-400 tw-to-blue-500 tw-rounded-full ${styling.imageSize} tw-bg-cover`}
                 style={styling?.userProfile}
             ></div>
             <div className="tw-flex tw-flex-col tw-items-start tw-gap-2">


### PR DESCRIPTION
**Fixed:**
- [x] User profile image now adjust to cover, fitting properly on the profile image container