### PR TITLE
Added dummy items to the event edit timeline

### DIFF
--- a/backend/modules/event/model.js
+++ b/backend/modules/event/model.js
@@ -194,7 +194,30 @@ const EventSchema = new mongoose.Schema({
     },
     eventTimeline: {
         type: EventTimelineSchema.mongoose,
-        default: { items: [] },
+        default: {
+            items: [
+                {
+                    title: 'Registration period',
+                    startTime: new Date(new Date().getTime()),
+                },
+                {
+                    title: 'Submission period',
+                    startTime: new Date(new Date().getTime() + 1),
+                },
+                {
+                    title: 'Review period',
+                    startTime: new Date(new Date().getTime() + 2),
+                },
+                {
+                    title: 'Event starts',
+                    startTime: new Date(new Date().getTime() + 3),
+                },
+                {
+                    title: 'Event ends',
+                    startTime: new Date(new Date().getTime() + 4),
+                },
+            ],
+        },
     },
     metaDescription: {
         type: String,

--- a/frontend/src/pages/_organise/slug/edit/timeline/TimelineForm.js
+++ b/frontend/src/pages/_organise/slug/edit/timeline/TimelineForm.js
@@ -208,7 +208,10 @@ export default ({ value, onChange }) => {
                             {value &&
                                 value
                                     .sort((a, b) =>
-                                        a.startTime < b.startTime ? -1 : 1,
+                                        Date.parse(a.startTime) <
+                                        Date.parse(b.startTime)
+                                            ? -1
+                                            : 1,
                                     )
                                     .map(renderListItem)}
                         </List>

--- a/frontend/src/pages/_organise/slug/edit/timeline/index.js
+++ b/frontend/src/pages/_organise/slug/edit/timeline/index.js
@@ -14,7 +14,7 @@ export default () => {
                     return (
                         <FormControl
                             label="Timeline"
-                            hint="Timeline for the event (displayed on the dashboard and the event information page). The event schedule will be added automatically afterwards."
+                            hint="Timeline for the event (displayed on the dashboard and the event information page). Adjust the dates to actual timestamps of your schedule."
                             error={form.errors[field.name]}
                             touched={form.touched[field.name]}
                         >


### PR DESCRIPTION
The dummy items are now shown and can be edited/deleted. The schedule is seen in the event page.
Fixed the description of the edit timeline a bit.