### PR TITLE
feat: Allow organisers to filter on custom questions

### DIFF
--- a/frontend/src/components/filters/FilterForm.js
+++ b/frontend/src/components/filters/FilterForm.js
@@ -1,7 +1,12 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
 
 import { useSelector } from 'react-redux'
-import { RegistrationFields, FilterTypes } from '@hackjunction/shared'
+import {
+    RegistrationFields,
+    FilterTypes,
+    FilterValues,
+    FilterHelpers,
+} from '@hackjunction/shared'
 import { makeStyles } from '@material-ui/core/styles'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import {
@@ -70,6 +75,7 @@ export default ({ onSubmit }) => {
             path: filterParams.path,
             type: filterType,
             value: filterValue,
+            valueType: filterParams.valueType,
         }
     }, [filterParams, filterType, filterValue])
 
@@ -79,11 +85,33 @@ export default ({ onSubmit }) => {
     }, [submitValue, onSubmit, handleClear])
 
     const filterOptions = useMemo(() => {
-        return RegistrationFields.filters.map(filter => ({
+        const defaultFields = RegistrationFields.filters.map(filter => ({
             value: JSON.stringify(filter),
             label: filter.label,
         }))
-    }, [])
+
+        const customQuestions = event.customQuestions
+            .map(section =>
+                section.questions.map(question => {
+                    return {
+                        path: FilterHelpers.createCustomQuestionFilterPath(
+                            section.name,
+                            question.name,
+                        ),
+                        label: question.label,
+                        type: FilterTypes.STRING,
+                        valueType: FilterValues.CUSTOM_QUESTION,
+                    }
+                }),
+            )
+            .flat()
+            .map(filter => ({
+                value: JSON.stringify(filter),
+                label: `Custom questions > ${filter.label}`,
+            }))
+
+        return [...defaultFields, ...customQuestions]
+    }, [event])
 
     const filterTypeOptions = useMemo(() => {
         if (!filterParams) return []

--- a/frontend/src/components/filters/FilterValueInput.js
+++ b/frontend/src/components/filters/FilterValueInput.js
@@ -62,6 +62,14 @@ const FilterValueInput = ({
                     return <TextInput label="Boolean field" {...inputParams} />
                 case FilterValues.DATE:
                     return <TextInput label="Date field" {...inputParams} />
+                case FilterValues.CUSTOM_QUESTION:
+                    return (
+                        <TextInput
+                            label="Enter the answer"
+                            placeholder="All data is stored as a string, to search for a boolean, write true/false"
+                            {...inputParams}
+                        />
+                    )
                 case FilterValues.GENDER:
                     return (
                         <Select

--- a/frontend/src/pages/_organise/slug/edit/questions/CustomSectionList/AddQuestionModal.js
+++ b/frontend/src/pages/_organise/slug/edit/questions/CustomSectionList/AddQuestionModal.js
@@ -226,15 +226,15 @@ export default ({
                     Machine name
                 </Typography>
                 <TextInput
-                    placeholder="favoriteAnimal"
+                    placeholder="favorite-animal"
                     disabled={editing}
                     value={data.name}
                     onChange={value => handleChange('name', value)}
                 />
                 <Typography variant="caption" paragraph>
                     A unique machine-readable name. This should be only letters,
-                    and be written in camelCase: e.g. letterOfMotivation. This
-                    field will not be visible to the end-user.
+                    and be written in snake-case: e.g. letter-of-motivation.
+                    This field will not be visible to the end-user.
                 </Typography>
                 <Typography variant="body1" className={classes.label}>
                     Question type

--- a/frontend/src/pages/_organise/slug/participants/default/index.js
+++ b/frontend/src/pages/_organise/slug/participants/default/index.js
@@ -1,12 +1,53 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { FilterHelpers } from '@hackjunction/shared'
+import { FilterHelpers, FilterValues } from '@hackjunction/shared'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 
 import Divider from 'components/generic/Divider'
 import AttendeeTable from 'components/tables/AttendeeTable'
 import FilterGroupMenu from 'components/filters/FilterGroupMenu'
+
+/**
+ * Creates a filter expression for the given custom question filter.
+ * The function finds the path for the answer in the registration
+ * and creates the explicit path to the answer object.
+ */
+const getCustomQuestionFilterResultForRegistration = (filter, registration) => {
+    const [sectionName, questionName] =
+        FilterHelpers.parseCustomQuestionFilterPath(filter.path)
+    const customAnswerIndex = registration.answers.CustomAnswers?.findIndex(
+        customAnswer =>
+            customAnswer.key === questionName &&
+            customAnswer.section === sectionName,
+    )
+
+    const customQuestionAnswerPath = `answers.CustomAnswers.${customAnswerIndex}.value`
+
+    return FilterHelpers.getFilterFunction({
+        ...filter,
+        path: customQuestionAnswerPath,
+    })(registration)
+}
+
+/**
+ * Separates the filters into "normal" and "custom" filters.
+ * Custom question filters use a specific `path` structure
+ * that does not work with regular filtering
+ */
+const partitionFilters = filters =>
+    filters.reduce(
+        (acc, filter) => {
+            if (filter.valueType === FilterValues.CUSTOM_QUESTION) {
+                acc.customQuestionFilters.push(filter)
+            } else {
+                acc.normalFieldFilters.push(filter)
+            }
+
+            return acc
+        },
+        { normalFieldFilters: [], customQuestionFilters: [] },
+    )
 
 export default () => {
     const registrations = useSelector(OrganiserSelectors.registrations)
@@ -15,7 +56,26 @@ export default () => {
     )
 
     const [filters, setFilters] = useState([])
-    const filtered = FilterHelpers.applyFilters(registrations, filters)
+    const { normalFieldFilters, customQuestionFilters } = useMemo(
+        () => partitionFilters(filters),
+        [filters],
+    )
+
+    const filtered = FilterHelpers.applyFilters(
+        registrations,
+        normalFieldFilters,
+    ).filter(registration => {
+        if (!customQuestionFilters) return true
+
+        return customQuestionFilters
+            .map(filter =>
+                getCustomQuestionFilterResultForRegistration(
+                    filter,
+                    registration,
+                ),
+            )
+            .every(passesFilter => !!passesFilter)
+    })
 
     return (
         <>

--- a/shared/constants/filter-values.js
+++ b/shared/constants/filter-values.js
@@ -10,6 +10,7 @@ const FilterValues = {
     LANGUAGE: 'LANGUAGE',
     STATUS: 'STATUS',
     TAG: 'TAG',
+    CUSTOM_QUESTION: 'CUSTOM_QUESTION',
 }
 
 module.exports = FilterValues

--- a/shared/helpers/filterHelpers.js
+++ b/shared/helpers/filterHelpers.js
@@ -3,139 +3,121 @@ const FilterFunctions = require('./filterFunctions')
 
 const FilterTypes = _FilterTypes.filterTypes
 
-const buildFiltersArray = filters => {
-    return filters.map((filter = {}) => {
-        switch (filter.type) {
-            case FilterTypes.NOT_EMPTY.id: {
-                return item => {
-                    return !FilterFunctions.isEmpty(item, filter.path)
-                }
+const getFilterFunction = (filter = {}) => {
+    switch (filter.type) {
+        case FilterTypes.NOT_EMPTY.id: {
+            return item => {
+                return !FilterFunctions.isEmpty(item, filter.path)
             }
-            case FilterTypes.IS_EMPTY.id: {
-                return item => {
-                    return FilterFunctions.isEmpty(item, filter.path)
-                }
-            }
-            case FilterTypes.EQUALS.id: {
-                return item => {
-                    return FilterFunctions.isEqualTo(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_EQUALS.id: {
-                return item => {
-                    return !FilterFunctions.isEqualTo(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.ONE_OF.id: {
-                return item => {
-                    return FilterFunctions.isOneOf(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_ONE_OF.id: {
-                return item => {
-                    return !FilterFunctions.isOneOf(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.CONTAINS.id: {
-                return item => {
-                    return FilterFunctions.contains(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_CONTAINS.id: {
-                return item => {
-                    return !FilterFunctions.contains(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.CONTAINS_ONE_OF.id: {
-                return item => {
-                    return FilterFunctions.containsOneOf(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_CONTAINS_ONE_OF.id: {
-                return item => {
-                    return !FilterFunctions.containsOneOf(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.LESS_THAN.id: {
-                return item => {
-                    return !FilterFunctions.isGte(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_LESS_THAN.id: {
-                return item => {
-                    return FilterFunctions.isGte(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.MORE_THAN.id: {
-                return item => {
-                    return !FilterFunctions.isLte(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.NOT_MORE_THAN.id: {
-                return item => {
-                    return FilterFunctions.isLte(
-                        item,
-                        filter.path,
-                        filter.value
-                    )
-                }
-            }
-            case FilterTypes.BOOLEAN_TRUE.id:
-                return item => {
-                    return FilterFunctions.isEqualTo(item, filter.path, true)
-                }
-            case FilterTypes.BOOLEAN_FALSE.id:
-                return item => {
-                    return FilterFunctions.isEqualTo(item, filter.path, false)
-                }
-            default:
-                return () => true
         }
-    })
+        case FilterTypes.IS_EMPTY.id: {
+            return item => {
+                return FilterFunctions.isEmpty(item, filter.path)
+            }
+        }
+        case FilterTypes.EQUALS.id: {
+            return item => {
+                return FilterFunctions.isEqualTo(
+                    item,
+                    filter.path,
+                    filter.value,
+                )
+            }
+        }
+        case FilterTypes.NOT_EQUALS.id: {
+            return item => {
+                return !FilterFunctions.isEqualTo(
+                    item,
+                    filter.path,
+                    filter.value,
+                )
+            }
+        }
+        case FilterTypes.ONE_OF.id: {
+            return item => {
+                return FilterFunctions.isOneOf(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.NOT_ONE_OF.id: {
+            return item => {
+                return !FilterFunctions.isOneOf(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.CONTAINS.id: {
+            return item => {
+                return FilterFunctions.contains(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.NOT_CONTAINS.id: {
+            return item => {
+                return !FilterFunctions.contains(
+                    item,
+                    filter.path,
+                    filter.value,
+                )
+            }
+        }
+        case FilterTypes.CONTAINS_ONE_OF.id: {
+            return item => {
+                return FilterFunctions.containsOneOf(
+                    item,
+                    filter.path,
+                    filter.value,
+                )
+            }
+        }
+        case FilterTypes.NOT_CONTAINS_ONE_OF.id: {
+            return item => {
+                return !FilterFunctions.containsOneOf(
+                    item,
+                    filter.path,
+                    filter.value,
+                )
+            }
+        }
+        case FilterTypes.LESS_THAN.id: {
+            return item => {
+                return !FilterFunctions.isGte(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.NOT_LESS_THAN.id: {
+            return item => {
+                return FilterFunctions.isGte(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.MORE_THAN.id: {
+            return item => {
+                return !FilterFunctions.isLte(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.NOT_MORE_THAN.id: {
+            return item => {
+                return FilterFunctions.isLte(item, filter.path, filter.value)
+            }
+        }
+        case FilterTypes.BOOLEAN_TRUE.id:
+            return item => {
+                return FilterFunctions.isEqualTo(item, filter.path, true)
+            }
+        case FilterTypes.BOOLEAN_FALSE.id:
+            return item => {
+                return FilterFunctions.isEqualTo(item, filter.path, false)
+            }
+        default:
+            return () => true
+    }
+}
+
+const createCustomQuestionFilterPath = (sectionName, questionName) =>
+    `${sectionName};${questionName}`
+
+const parseCustomQuestionFilterPath = path => {
+    const [sectionName, questionName] = path.split(';')
+    return [sectionName, questionName]
+}
+
+const buildFiltersArray = filters => {
+    return filters.map(getFilterFunction)
 }
 
 const applyFilters = (items, filters) => {
@@ -151,4 +133,7 @@ const applyFilters = (items, filters) => {
 
 module.exports = {
     applyFilters,
+    getFilterFunction,
+    createCustomQuestionFilterPath,
+    parseCustomQuestionFilterPath,
 }


### PR DESCRIPTION
Adds the ability to filter on custom questions/answers in the "Participants" view for organisers.

Note: It looks like saving a filter is broken, I'll take a look at that as well soon.


https://github.com/hackjunction/JunctionApp/assets/17903881/e2bc08ca-a6a8-453c-ab1c-51392572f169

