### PR TITLE
Validate project name uniqueness on submission form

### DIFF
--- a/backend/modules/project/controller.js
+++ b/backend/modules/project/controller.js
@@ -40,6 +40,11 @@ controller.getProjectsByEventAndTeam = (eventId, teamId) => {
     })
 }
 
+controller.isProjectNameTaken = async (eventId, projectName) => {
+    const projects = await controller.getAllProjectsByEvent(eventId)
+    return projects.find(p => p.name === projectName) !== undefined
+}
+
 controller.createProjectForEventAndTeam = async (event, team, data) => {
     const schema = yup.object().shape(ProjectSchema(event))
     const validatedData = await schema.validate(data, { stripUnknown: true })

--- a/backend/modules/project/routes.js
+++ b/backend/modules/project/routes.js
@@ -37,6 +37,22 @@ router
     )
 
 router
+    .route('/:slug/validate')
+    /** Validate project before submission on UI, non-blocking (doesn't prevent saving to db) */
+    .post(
+        getEventFromParams,
+        hasToken,
+        asyncHandler(async (req, res) => {
+            const isProjectNameTaken =
+                await ProjectController.isProjectNameTaken(
+                    req.event._id,
+                    req.body.data.projectName,
+                )
+            return res.status(200).json({ isProjectNameTaken })
+        }),
+    )
+
+router
     .route('/:slug/team')
     /** Get the projects submitted by a user's team at a given event */
     .get(

--- a/frontend/src/services/projects.js
+++ b/frontend/src/services/projects.js
@@ -33,6 +33,14 @@ ProjectsService.updateProjectForEventAndTeam = (idToken, eventSlug, data) => {
     )
 }
 
+ProjectsService.validateProject = (idToken, eventSlug, data) => {
+    return _axios.post(
+        `/projects/${eventSlug}/validate`,
+        { data },
+        config(idToken),
+    )
+}
+
 ProjectsService.getAllProjectsAsOrganiser = (idToken, eventSlug) => {
     return _axios.get(`/projects/${eventSlug}/admin`, config(idToken))
 }


### PR DESCRIPTION
Adds a small API endpoint to validate project names. It can be extended in the future with other validations.

I've decided to create a separate endpoint for this instead of putting into an `onSave` callback because this is a "non-blocking" error. Users can still save the project if they want to, this is more of a heads-up that their project is similar to another one. We could make this stricter in the future, but this is a good starting point.
![Screenshot 2023-09-05 at 21 47 01](https://github.com/hackjunction/JunctionApp/assets/17903881/c8dcf927-8506-48f1-86d5-0befa54316b5)

