### PR TITLE
Update migration file to add a valid default email for emailConfig's senderEmail field

### DIFF
--- a/backend/migrations/19-add-emailConfig-to-event.js
+++ b/backend/migrations/19-add-emailConfig-to-event.js
@@ -15,7 +15,7 @@ module.exports = {
                     $set: {
                         emailConfig: {
                             senderName: "",
-                            senderEmail: "",
+                            senderEmail: "noreply@hackjunction.com",
                             acceptanceEmail: {
                                 title: "",
                                 subtitle: "",


### PR DESCRIPTION
Update migration file to add a valid default email for emailConfig's senderEmail field to fix the `not a valid email address!` error