### PR TITLE
Create a new migration that updates all `Event` documents with empty senderEmail fields with a valid email address

### DIFF
--- a/backend/migrations/20-fix-empty-senderEmail-in-event.js
+++ b/backend/migrations/20-fix-empty-senderEmail-in-event.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose')
+const Promise = require('bluebird')
+
+module.exports = {
+    index: 20,
+    name: '20-fix-empty-senderEmail-in-event',
+    description: 'Replace empty senderEmail with noreply@hackjunction.com',
+    run: async () => {
+        // Update emailConfig.senderEmail field for documents with an empty senderEmail
+        const resSenderEmail = await mongoose
+            .model('Event')
+            .updateMany(
+                { 'emailConfig.senderEmail': { $in: [null, ""] } },
+                {
+                    $set: {
+                        'emailConfig.senderEmail': "noreply@hackjunction.com"
+                    }
+                }
+            )
+
+        console.log('Done updating empty senderEmail fields', resSenderEmail.n, resSenderEmail.nModified)
+
+        return Promise.resolve()
+    },
+}

--- a/backend/migrations/index.js
+++ b/backend/migrations/index.js
@@ -23,6 +23,7 @@ const migrations = [
     require('./17-add-specific-hackerpacks-to-event'),
     require('./18-add-event-newsletter-link-to-event'),
     require('./19-add-emailConfig-to-event'),
+    require('./20-fix-empty-senderEmail-in-event'),
 
 
 


### PR DESCRIPTION
Create a new migration that updates all `Event` documents with empty senderEmail fields with a valid email address to fix the `not a valid email address!` error