### PR TITLE
fix: Event page scripts submission

### DIFF
--- a/backend/modules/event/graphql.js
+++ b/backend/modules/event/graphql.js
@@ -43,6 +43,7 @@ const {
     MeetingRoom,
     MeetingRoomInput,
     EventPageScript,
+    EventPageScriptInput,
 } = require('../graphql-shared-types')
 
 const Organization = require('../organization/model')
@@ -275,6 +276,9 @@ const EventInput = new GraphQLInputObjectType({
         },
         webhooks: {
             type: GraphQLList(WebhookInput),
+        },
+        pageScripts: {
+            type: GraphQLList(EventPageScriptInput),
         },
         meetingsEnabled: {
             type: GraphQLBoolean,

--- a/shared/schemas/EventPageScript.js
+++ b/shared/schemas/EventPageScript.js
@@ -1,5 +1,10 @@
 const mongoose = require('mongoose')
-const { GraphQLObjectType, GraphQLString, GraphQLNonNull } = require('graphql')
+const {
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLNonNull,
+    GraphQLInputObjectType,
+} = require('graphql')
 const { GraphQLBoolean } = require('graphql')
 
 const EventPageScriptSchema = new mongoose.Schema({
@@ -30,7 +35,23 @@ const EventPageScriptType = new GraphQLObjectType({
     },
 })
 
+const EventPageScriptInput = new GraphQLInputObjectType({
+    name: 'EventPageScriptInput',
+    fields: {
+        page: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        script: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        approved: {
+            type: GraphQLNonNull(GraphQLBoolean),
+        },
+    },
+})
+
 module.exports = {
     mongoose: EventPageScriptSchema,
     graphql: EventPageScriptType,
+    graphqlInput: EventPageScriptInput,
 }

--- a/shared/schemas/index.js
+++ b/shared/schemas/index.js
@@ -80,6 +80,7 @@ const SharedSchema = new GraphQLSchema({
         MeetingRoom.graphql,
         MeetingRoom.graphqlInput,
         EventPageScript.graphql,
+        EventPageScript.graphqlInput,
     ],
 })
 


### PR DESCRIPTION
Event page scripts couldn't be saved due to a missing input type. This change makes the submission form save successfully.