### PR TITLE
Feature - Re-enabled talent matchmaking and other minor changes

### DIFF
--- a/backend/common/utils/userProfileUtils.js
+++ b/backend/common/utils/userProfileUtils.js
@@ -65,8 +65,8 @@ const userProfileUtils = {
                 ? registrationData.answers.education
                 : profileData.education,
             social: {
-                github: registrationData.answers.education
-                    ? registrationData.answers.education
+                github: registrationData.answers.github
+                    ? registrationData.answers.github
                     : profileData.github,
                 linkedin: registrationData.answers.linkedin
                     ? registrationData.answers.linkedin

--- a/backend/common/utils/userProfileUtils.js
+++ b/backend/common/utils/userProfileUtils.js
@@ -2,19 +2,13 @@
 
 const userProfileUtils = {
     publicProfileBuilder: profileData => {
+        //Do not include any sensitive information (email, nationality, gender, date of birth) in the public profile
         return {
             userId: profileData.userId,
             profile: {
                 firstName: profileData.firstName,
                 lastName: profileData.lastName,
-                // email: profileData.email,
-                // gender: profileData.gender,
-                // nationality: profileData.nationality,
-                // countryOfResidence: profileData.countryOfResidence,
-                // dateOfBirth: profileData.dateOfBirth,
                 spokenLanguages: profileData.spokenLanguages,
-                // TODO remove profilePicture and replace with avatar property
-                // profilePicture: profileData.avatar || null,
                 avatar: profileData.avatar || null,
                 headline: profileData.headline,
                 biography: profileData.biography,
@@ -32,10 +26,61 @@ const userProfileUtils = {
             },
         }
     },
-    recruitmentProfileBuilder: function (profileData) {
+    recruitmentProfileBuilder: (registrationData, profileData) => {
+        //This combines the registration data with the profile data
+        //Don't include personal information like gender, nationality or date of birth
         return {
-            ...this.publicProfileBuilder(profileData),
-            recruitmentOptions: profileData.recruitmentOptions,
+            userId: profileData.userId,
+            profile: {
+                firstName: profileData.firstName,
+                lastName: profileData.lastName,
+                email: profileData.email,
+                countryOfResidence: registrationData.answers.countryOfResidence
+                    ? registrationData.answers.countryOfResidence
+                    : profileData.countryOfResidence,
+                spokenLanguages: registrationData.answers.spokenLanguages
+                    ? registrationData.answers.spokenLanguages
+                    : profileData.spokenLanguages,
+                avatar: profileData.avatar || null,
+                headline: registrationData.answers.headline
+                    ? registrationData.answers.headline
+                    : profileData.headline,
+                biography: registrationData.answers.biography
+                    ? registrationData.answers.biography
+                    : profileData.biography,
+            },
+            skills: registrationData.answers.skills
+                ? registrationData.answers.skills
+                : profileData.skills,
+            roles: registrationData.answers.roles
+                ? registrationData.answers.roles
+                : profileData.roles,
+            industriesOfInterest: registrationData.answers.industriesOfInterest
+                ? registrationData.answers.industriesOfInterest
+                : profileData.industriesOfInterest,
+            themesOfInterest: registrationData.answers.themesOfInterest
+                ? registrationData.answers.themesOfInterest
+                : profileData.themesOfInterest,
+            education: registrationData.answers.education
+                ? registrationData.answers.education
+                : profileData.education,
+            social: {
+                github: registrationData.answers.education
+                    ? registrationData.answers.education
+                    : profileData.github,
+                linkedin: registrationData.answers.linkedin
+                    ? registrationData.answers.linkedin
+                    : profileData.linkedin,
+                portfolio: registrationData.answers.portfolio
+                    ? registrationData.answers.portfolio
+                    : profileData.portfolio,
+                curriculumVitae: registrationData.answers.curriculumVitae
+                    ? registrationData.answers.curriculumVitae
+                    : profileData.curriculumVitae,
+            },
+            recruitmentOptions: registrationData.answers.recruitmentOptions
+                ? registrationData.answers.recruitmentOptions
+                : profileData.recruitmentOptions,
             registrations: profileData.registrations,
         }
     },

--- a/backend/modules/recruitment/model.js
+++ b/backend/modules/recruitment/model.js
@@ -12,8 +12,7 @@ const RecruitmentActionSchema = new mongoose.Schema(
             type: String,
             required: true,
         },
-        // should be with z, not s
-        // TODO Migrate this shit when done with the organizations feature
+        // TODO Migrate this when done with the organizations feature
         organisation: {
             type: String,
             required: true,
@@ -27,29 +26,33 @@ const RecruitmentActionSchema = new mongoose.Schema(
             type: mongoose.Mixed,
             default: {},
         },
+        event: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Event',
+        },
     },
-    { toJSON: { virtuals: true } }
+    // { toJSON: { virtuals: true } },
 )
 
-RecruitmentActionSchema.virtual('_user', {
-    ref: 'UserProfile', // The model to use
-    localField: 'user', // Find people where `localField`
-    foreignField: 'userId', // is equal to `foreignField`
-    justOne: true,
-})
+// RecruitmentActionSchema.virtual('_user', {
+//     ref: 'UserProfile', // The model to use
+//     localField: 'user', // Find people where `localField`
+//     foreignField: 'userId', // is equal to `foreignField`
+//     justOne: true,
+// })
 
-RecruitmentActionSchema.virtual('_recruiter', {
-    ref: 'UserProfile', // The model to use
-    localField: 'recruiter', // Find people where `localField`
-    foreignField: 'userId', // is equal to `foreignField`
-    justOne: true,
-})
+// RecruitmentActionSchema.virtual('_recruiter', {
+//     ref: 'UserProfile', // The model to use
+//     localField: 'recruiter', // Find people where `localField`
+//     foreignField: 'userId', // is equal to `foreignField`
+//     justOne: true,
+// })
 
 RecruitmentActionSchema.set('timestamps', true)
 
 const RecruitmentAction = mongoose.model(
     'RecruitmentAction',
-    RecruitmentActionSchema
+    RecruitmentActionSchema,
 )
 
 module.exports = { RecruitmentAction, RecruitmentActionSchema }

--- a/backend/modules/recruitment/routes.js
+++ b/backend/modules/recruitment/routes.js
@@ -8,7 +8,6 @@ const RecruitmentController = require('./controller')
 const { hasToken } = require('../../common/middleware/token')
 const { hasPermission } = require('../../common/middleware/permissions')
 
-
 const queryUsers = asyncHandler(async (req, res) => {
     const users = await RecruitmentController.queryProfiles(req.body, req.user)
     return res.status(200).json(users)
@@ -18,12 +17,12 @@ const getUserProfileRecruitment = asyncHandler(async (req, res) => {
     const userProfile = await RecruitmentController.getRecruitmentProfile(
         req.params.id,
         req.user.sub,
+        req.query.event,
     )
     return res.status(200).json(userProfile)
 })
 
 const getRecruiterActions = asyncHandler(async (req, res) => {
-    console.log("getRecruiterActions", req.params)
     const actionHistory = await RecruitmentController.getRecruiterActions(
         req.user,
         req.params.organisation,
@@ -32,8 +31,6 @@ const getRecruiterActions = asyncHandler(async (req, res) => {
 })
 
 const saveRecruiterAction = asyncHandler(async (req, res) => {
-    console.log(req.user,
-        req.body,)
     const actionHistory = await RecruitmentController.saveRecruiterAction(
         req.user,
         req.body,

--- a/backend/modules/registration/controller.js
+++ b/backend/modules/registration/controller.js
@@ -331,11 +331,21 @@ controller.updateTravelGrantStatus = (user, event, status) => {
         })
 }
 
+controller.getRegistrationsForQuery = async (query, pagination) => {
+    const found = await Registration.find(query)
+        .sort('updatedAt')
+        .skip(pagination.skip)
+        .limit(pagination.limit)
+
+    const count = Array.isArray(found) ? found.length : 0
+    return { found, count }
+}
+
 controller.getRegistrationsForEvent = (eventId, getFullStrings = false) => {
     return Registration.find({
         event: eventId,
     }).then(registrations => {
-        /** Do some minor optimisation here to cut down on size */
+        /** TODO Do some minor optimisation here to cut down on size */
         return registrations.map(document => {
             const reg = document.toObject()
             if (!getFullStrings) {

--- a/backend/modules/user-profile/controller.js
+++ b/backend/modules/user-profile/controller.js
@@ -56,7 +56,6 @@ controller.getUserProfilesPublic = userIds => {
     })
 }
 
-
 controller.createUserProfile = (data, userId) => {
     const userProfile = new UserProfile({
         userId,
@@ -124,10 +123,12 @@ controller.getUsersByEmail = email => {
 }
 
 // a function to get the user id by email
-controller.getUserIdByEmail = async (email) => {
+controller.getUserIdByEmail = async email => {
     const profiles = await controller.getUsersByEmail(email)
     if (profiles.length === 0) {
-        throw new NotFoundError(`User profile with email ${email} does not exist`)
+        throw new NotFoundError(
+            `User profile with email ${email} does not exist`,
+        )
     }
     return profiles[0].userId
 }
@@ -147,22 +148,19 @@ controller.getRecruiters = () => {
 
 controller.updateRecruiter = (userId, event, organisation) => {
     return UserProfile.findOne({ userId }).then(user => {
-        user.recruiterEvents = user.recruiterEvents.concat(
-            {
-                eventId: event,
-                organisation: organisation,
-            },
-        )
+        user.recruiterEvents = user.recruiterEvents.concat({
+            eventId: event,
+            organisation: organisation,
+        })
         return user.save()
     })
-
-
 }
 
 controller.deleteRecruiter = (userId, event) => {
     return UserProfile.findOne({ userId }).then(user => {
-        user.recruiterEvents = user.recruiterEvents.filter(recruiterEvent =>
-            recruiterEvent.eventId !== event)
+        user.recruiterEvents = user.recruiterEvents.filter(
+            recruiterEvent => recruiterEvent.eventId !== event,
+        )
         return user.save()
     })
 }
@@ -173,18 +171,17 @@ controller.updateRecruitersAdmin = (userId, events, organisation) => {
             events.map(event => ({
                 eventId: event,
                 organisation: organisation,
-            })))
+            })),
+        )
         return user.save()
     })
 }
 
-controller.deleteRecruitersAdmin = (userId) => {
+controller.deleteRecruitersAdmin = userId => {
     return UserProfile.findOne({ userId }).then(user => {
         user.recruiterEvents = []
         return user.save()
     })
 }
-
-
 
 module.exports = controller

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -443,5 +443,6 @@
     "Project_evaluation_final_score_hint_":"First assign a score to each criteria",
     "Project_evaluation_feedback_":"Feedback message",
     "Project_evaluation_feedback_hint_":"Share your feedback with the team",
-    "Project_evaluation_feedback_placeholder_":"This project is great because..."
+    "Project_evaluation_feedback_placeholder_":"This project is great because...",
+    "Event_waiting_approval_":"The event will be published once approved by admins. Questions about the approval process can be directed to hello@hackjunction.com"
 }

--- a/frontend/src/components/Participant/ProfileInfo/index.js
+++ b/frontend/src/components/Participant/ProfileInfo/index.js
@@ -133,7 +133,6 @@ export default ({ user = {} }) => {
 
     return (
         <>
-            {/* {(user.profile?.biography || user?.recruitmentOptions) && ( */}
             <div className="tw-rounded-lg tw-shadow-md tw-bg-white tw-p-8 tw-flex tw-flex-col tw-gap-4">
                 {user.profile.biography && (
                     <div>
@@ -227,7 +226,7 @@ export default ({ user = {} }) => {
                         </Typography>
                     </div>
                 )}
-                {/* {user.profile.email && (
+                {user.profile.email && (
                     <div>
                         <Typography
                             className="tw-tracking-tight tw-font-normal tw-text-gray-600"
@@ -244,7 +243,7 @@ export default ({ user = {} }) => {
                             {user.profile.email}
                         </Typography>
                     </div>
-                )} */}
+                )}
                 {user.profile.countryOfResidence && (
                     <div>
                         <Typography

--- a/frontend/src/components/Participant/RecruitmentFavorites/index.js
+++ b/frontend/src/components/Participant/RecruitmentFavorites/index.js
@@ -3,11 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { goBack } from 'connected-react-router'
 import { useSelector, useDispatch } from 'react-redux'
 import { makeStyles, lighten } from '@material-ui/core/styles'
-import {
-    Button as MuiButton,
-    IconButton,
-    Tooltip,
-} from '@material-ui/core'
+import { Button as MuiButton, IconButton, Tooltip } from '@material-ui/core'
 
 import StarIcon from '@material-ui/icons/Star'
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos'
@@ -97,17 +93,21 @@ export default ({ user = {} }) => {
     // Toggle favorited state locally for instant feedback on favorite action
     const [_isFavorite, setIsFavorite] = useState(isFavorite)
     const classes = useStyles({ isFavorite: _isFavorite })
-    const event = useSelector(DashboardSelectors.event)._id
+    const eventId = useSelector(DashboardSelectors.event)._id
     const recEvents = useSelector(UserSelectors.userProfileRecruiterEvents)
-
 
     const handleFavorite = useCallback(async () => {
         const organisation = recEvents.find(e => {
-            return e.eventId === event
+            return e.eventId === eventId
         }).organisation
         setIsFavorite(!_isFavorite)
         const { error } = await dispatch(
-            RecruitmentActions.toggleFavorite(user.userId, _isFavorite, organisation),
+            RecruitmentActions.toggleFavorite(
+                user.userId,
+                _isFavorite,
+                organisation,
+                eventId,
+            ),
         )
         if (error) {
             dispatch(SnackbarActions.error('Something went wrong...'))

--- a/frontend/src/components/filters/FilterGroupMenu.js
+++ b/frontend/src/components/filters/FilterGroupMenu.js
@@ -25,8 +25,8 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default ({
-    onChange = () => { },
-    onSelectedChange = () => { },
+    onChange = () => {},
+    onSelectedChange = () => {},
     showEdit = true,
 }) => {
     const filterGroups = useSelector(OrganiserSelectors.filterGroups)
@@ -80,7 +80,7 @@ export default ({
         let items = [
             {
                 label: t('All_participants_'),
-                description: t('No filters'),
+                description: t('No_filters_'),
                 filters: [],
                 isDefault: true,
             },

--- a/frontend/src/components/generic/Markdown/index.js
+++ b/frontend/src/components/generic/Markdown/index.js
@@ -135,6 +135,7 @@ const Markdown = React.memo(
                             return (
                                 <Link to={props.href}>
                                     <Typography
+                                        component={'span'}
                                         className={classes.hyperlink}
                                         display="inline"
                                         variant="body1"

--- a/frontend/src/components/generic/_Table/ActionBar.js
+++ b/frontend/src/components/generic/_Table/ActionBar.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
-import { Box, Typography, Button } from '@material-ui/core'
+import { Box, Typography } from '@material-ui/core'
+import Button from '../Button'
 import { makeStyles } from '@material-ui/core/styles'
 import { motion } from 'framer-motion'
 import { CSVLink } from 'react-csv'

--- a/frontend/src/components/layouts/PageWrapper/index.js
+++ b/frontend/src/components/layouts/PageWrapper/index.js
@@ -8,7 +8,7 @@ const PageWrapper = ({
     loadingText = 'Loading',
     error = false,
     errorText = 'Oops, something went wrong...',
-    errorDesc = 'Please reload the page to try again',
+    errorDesc = 'Please reload the page to try again or go back to the previous page. If the problem persists, please contact support.',
     wrapContent = true,
     wrapperProps = {},
     showErrorMessage = false,
@@ -33,7 +33,7 @@ const PageWrapper = ({
             )
         }
         if (error || errorMessage) {
-            console.log("errors", error, errorMessage)
+            console.log('errors', error, errorMessage)
             // TODO Oops something went wrong happens here. Make it better :D
             return (
                 <Box

--- a/frontend/src/components/messaging/alerts/index.js
+++ b/frontend/src/components/messaging/alerts/index.js
@@ -3,26 +3,21 @@ import moment from 'moment-timezone'
 import { Typography } from '@material-ui/core'
 import GradientBox from 'components/generic/GradientBox'
 
-// const useStyles = makeStyles(theme => ({
-//     // root: {
-//     //     height: '90%',
-//     //     overflow: 'auto',
-//     // },
-// }))
-
 export function Alerts({ alerts = [] }) {
     const sortedAlerts = alerts.sort(
         (a, b) => +new Date(b.sentAt) - +new Date(a.sentAt),
     )
-    // const classes = useStyles()
-
+    console.log('alerts', alerts)
     return (
         <div
             className={'tw-flex tw-flex-col tw-gap-2 tw-overflow-auto tw-h-64'}
         >
-            {sortedAlerts.map(a => (
-                // <Grid style={{ paddingTop: '10px' }}>
-                <GradientBox color="theme_purple" p={2}>
+            {sortedAlerts.map((a, index) => (
+                <GradientBox
+                    key={`${a.sender}-${index}`}
+                    color="theme_purple"
+                    p={2}
+                >
                     <Typography
                         variant="subtitle1"
                         className="tw-whitespace-pre"

--- a/frontend/src/components/navbars/BasicNavBar/index.js
+++ b/frontend/src/components/navbars/BasicNavBar/index.js
@@ -1,34 +1,9 @@
 import React from 'react'
-// import UserMenu from 'components/UserMenu'
 import UserAvatar from 'components/UserAvatar'
 import LanguageMenu from 'components/LanguageMenu'
 
-// import { Typography } from '@material-ui/core'
-// import { makeStyles } from '@material-ui/core/styles'
-
-// import navbarWaves from 'assets/images/nawbar_waves.svg'
-
-// const useStyles = makeStyles(theme => ({
-//     // wrapper: {
-//     //     width: '100%',
-//     //     height: '78px',
-//     //     //background: 'black',
-//     //     background: 'assets/images/nawbar_waves.svg',
-//     //     padding: theme.spacing(0, 2),
-//     // },
-//     // inner: {
-//     //     display: 'flex',
-//     //     flexDirection: 'row',
-//     //     justifyContent: 'right',
-//     //     margin: '0',
-//     //     height: '100%',
-//     // },
-// }))
-
-const BasicNavBar = ({ text }) => {
-    // const classes = useStyles()
+const BasicNavBar = () => {
     return (
-        // <div className={classes.wrapper}>
         <div className="tw-w-full tw-p-2 tw-bg-wave-pattern tw-bg-black ">
             <div className={'tw-flex tw-justify-end tw-items-center'}>
                 <LanguageMenu />

--- a/frontend/src/components/projects/ProjectDetail/ProjectTeam.js
+++ b/frontend/src/components/projects/ProjectDetail/ProjectTeam.js
@@ -36,13 +36,11 @@ const ProjectTeam = React.memo(({ hiddenUsers, teamId, showFullTeam }) => {
     const [loading, setLoading] = useState(false)
     const idToken = useSelector(AuthSelectors.getIdToken)
     const hasRecruiterAccess = useSelector(AuthSelectors.hasRecruiterAccess)
-    // TODO IMPORTANT hide team members in backend
     const fetchTeamMembers = useCallback(async () => {
         if (!teamId) return
         setLoading(true)
         try {
             if (hasRecruiterAccess) {
-                console.log('has recruiter access')
                 const data = await UserProfilesService.getUserProfilesByTeamId(
                     teamId,
                     idToken,
@@ -80,12 +78,6 @@ const ProjectTeam = React.memo(({ hiddenUsers, teamId, showFullTeam }) => {
         return null
     }
 
-    const secondaryText = member => {
-        if (!showFullTeam) return null
-        return `${member.email} // ${
-            member.phoneNumber ? member.phoneNumber.countryCode : ''
-        } ${member.phoneNumber ? member.phoneNumber.number : ''}`
-    }
     return (
         <List>
             {teamMembers.map(member => {
@@ -94,10 +86,6 @@ const ProjectTeam = React.memo(({ hiddenUsers, teamId, showFullTeam }) => {
                         <ListItemAvatar>
                             <Avatar src={member.avatar} />
                         </ListItemAvatar>
-                        <ListItemText
-                            primary={`${member.firstName} ${member.lastName}`}
-                            secondary={secondaryText(member)}
-                        />
                         {typeof member.recruitmentOptions !== 'undefined' &&
                             member.recruitmentOptions.consent && (
                                 <IfRecruiter memberId={member.userId} />

--- a/frontend/src/components/projects/ProjectsGridItem/index.js
+++ b/frontend/src/components/projects/ProjectsGridItem/index.js
@@ -279,10 +279,13 @@ const ProjectsGridItem = ({
                                                 key={index}
                                                 title={`Reviewed by ${
                                                     project?.scoreData
-                                                        ?.reviewers?.length - 1
+                                                        ?.reviewers?.length -
+                                                    (reviewIndexLimit + 1) +
+                                                    1
                                                 } more ${
                                                     project?.scoreData
                                                         ?.reviewers?.length -
+                                                        (reviewIndexLimit + 1) +
                                                         1 >
                                                     1
                                                         ? 'people'
@@ -292,7 +295,9 @@ const ProjectsGridItem = ({
                                                 <Avatar>
                                                     +
                                                     {project?.scoreData
-                                                        ?.reviewers?.length - 1}
+                                                        ?.reviewers?.length -
+                                                        (reviewIndexLimit + 1) +
+                                                        1}
                                                 </Avatar>
                                             </Tooltip>
                                         )

--- a/frontend/src/components/tables/ProjectsTable/index.js
+++ b/frontend/src/components/tables/ProjectsTable/index.js
@@ -7,40 +7,18 @@ import { Table, Filters, Sorters } from 'components/generic/_Table'
 import EditProjectModal from 'components/modals/EditProjectModal'
 import _ from 'lodash'
 import { CSVLink } from 'react-csv'
-import { projectURLgenerator } from 'utils/dataModifiers'
+import { flattenObject, projectURLgenerator } from 'utils/dataModifiers'
+
+const skipArray = ['_id', '__v', 'id', 'key', 'section']
+const stringEscapeArray = ['description', 'name', 'punchline']
 
 const ProjectsTable = ({ projects }) => {
     const event = useSelector(OrganiserSelectors.event)
-
-    const skipArray = ['_id', '__v', 'id', 'key', 'section']
-    const stringEscapeArray = ['description', 'name', 'punchline']
-    const flattenObject = ob => {
-        let toReturn = {}
-        for (let i in ob) {
-            if (!ob.hasOwnProperty(i) || skipArray.some(val => val === i))
-                continue
-
-            if (stringEscapeArray.some(val => val === i)) {
-                toReturn[i] = ob[i].replace(/"/g, '""')
-                continue
-            } else if (typeof ob[i] === 'object' && ob[i] !== null) {
-                let flatObject = flattenObject(ob[i])
-                for (let x in flatObject) {
-                    if (!flatObject.hasOwnProperty(x)) continue
-                    toReturn[i + '.' + x] = flatObject[x].replace(/"/g, '""')
-                }
-            } else {
-                toReturn[i] = ob[i]
-            }
-        }
-        return toReturn
-    }
 
     const [selected, setSelected] = useState([])
 
     const [selectedProject, setSelectedProject] = useState(null)
 
-    // TODO config columsn (table only in physical events)
     const openSingleEdit = useCallback(row => {
         setSelectedProject(row.original)
     }, [])
@@ -115,11 +93,15 @@ const ProjectsTable = ({ projects }) => {
                                             event.slug,
                                             item.original._id,
                                         ),
-                                        ...flattenObject(item.original),
+                                        ...flattenObject(
+                                            item.original,
+                                            skipArray,
+                                            stringEscapeArray,
+                                        ),
                                     }
                                     return returnObject
                                 })}
-                                filename="export.csv"
+                                filename="project-exports.csv"
                             >
                                 Export selected
                             </CSVLink>
@@ -163,7 +145,7 @@ const ProjectsTable = ({ projects }) => {
                                         }
                                     }),
                                 )}
-                                filename="export.csv"
+                                filename="project-exports-gavel.csv"
                             >
                                 Export for gavel
                             </CSVLink>

--- a/frontend/src/pages/_admin/default/OrganizationList.js
+++ b/frontend/src/pages/_admin/default/OrganizationList.js
@@ -70,7 +70,7 @@ export default ({ data = [] }) => {
                     <>
                         <Grid item xs={12} md={12} xl={12}>
                             <GradientBox color="theme_white" p={3}>
-                                <Grid container justify="center">
+                                <Grid container justifyContent="center">
                                     <Grid item xs={3}>
                                         <img
                                             alt={org.name}

--- a/frontend/src/pages/_dashboard/index.js
+++ b/frontend/src/pages/_dashboard/index.js
@@ -1,13 +1,13 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useRouteMatch } from 'react-router'
 import { Route, Switch, Redirect } from 'react-router-dom'
 import SlugPage from './renderDashboard'
 import DefaultPage from './renderDashboard/default'
-import { useDispatch } from 'react-redux'
+// import { useDispatch } from 'react-redux'
 
 export default () => {
     const match = useRouteMatch()
-    const dispatch = useDispatch()
+    // const dispatch = useDispatch()
 
     //redirect to right event page, default, or out
     return (

--- a/frontend/src/pages/_dashboard/index.js
+++ b/frontend/src/pages/_dashboard/index.js
@@ -1,13 +1,79 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useRouteMatch } from 'react-router'
 import { Route, Switch, Redirect } from 'react-router-dom'
 import SlugPage from './renderDashboard'
 import DefaultPage from './renderDashboard/default'
-// import { useDispatch } from 'react-redux'
+import {
+    useMyEvents,
+    useActiveEvents,
+    usePastEvents,
+} from 'graphql/queries/events'
+import { useDispatch, useSelector } from 'react-redux'
+import * as DashboardSelectors from 'redux/dashboard/selectors'
+import * as DashboardActions from 'redux/dashboard/actions'
+import * as AuthSelectors from 'redux/auth/selectors'
+import * as UserSelectors from 'redux/user/selectors'
+import * as UserActions from 'redux/user/actions'
 
 export default () => {
     const match = useRouteMatch()
-    // const dispatch = useDispatch()
+    const dispatch = useDispatch()
+    const event = useSelector(DashboardSelectors.event)
+
+    // Set up browser notifications
+    useEffect(() => {
+        if ('Notification' in window && Notification.permission !== 'granted') {
+            Notification.requestPermission()
+        }
+    }, [])
+
+    //SET EVENTS TO DISPLAY
+    const [organizerEvents, loading] = useMyEvents()
+    const [activeEvents, loadingActive] = useActiveEvents({}) //active events, from these we select where to rediret, or default
+    const [pastEvents, loadingPast] = usePastEvents({ limit: 3 })
+
+    //FIND ROLES AVAILABLE FOR USER
+    const isPartner =
+        useSelector(AuthSelectors.idTokenData)?.roles?.includes('Recruiter') &&
+        !useSelector(AuthSelectors.idTokenData)?.roles?.includes(
+            'SuperAdmin',
+        ) &&
+        useSelector(UserSelectors.userProfileRecruiterEvents)
+            ?.map(e => e.eventId)
+            .includes(event?._id)
+
+    const isOrganizer =
+        useSelector(AuthSelectors.idTokenData)?.roles?.some(r =>
+            ['Organiser', 'AssistantOrganiser', 'SuperAdmin'].includes(r),
+        ) && organizerEvents?.map(e => e._id).includes(event?._id)
+
+    // Set up browser notifications
+    useEffect(() => {
+        if ('Notification' in window && Notification.permission !== 'granted') {
+            Notification.requestPermission()
+        }
+    }, [])
+
+    useEffect(() => {
+        //does not take multiple roles into a count
+        if (isPartner) {
+            dispatch(UserActions.setAccessRight('partner'))
+        } else if (isOrganizer) {
+            dispatch(UserActions.setAccessRight('organizer'))
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!loading) {
+            dispatch(UserActions.organizerEvents(organizerEvents))
+        }
+        if (!loadingActive) {
+            dispatch(DashboardActions.activeEvents(activeEvents))
+        }
+        if (!loadingPast) {
+            dispatch(DashboardActions.pastEvents(pastEvents))
+        }
+    }, [organizerEvents, activeEvents, pastEvents])
 
     //redirect to right event page, default, or out
     return (

--- a/frontend/src/pages/_dashboard/renderDashboard/default/events/Organizer.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/default/events/Organizer.js
@@ -16,7 +16,7 @@ import * as UserActions from 'redux/user/actions'
 
 import CreateEventCard from './CreateEventCard'
 import TextInput from '../../../../../components/inputs/TextInput'
-import { debugGroup } from 'utils/debuggingTools'
+import { useDebounce } from 'hooks/customHooks'
 
 //TODO: make this to use theme colors and make prettier
 const useStyles = makeStyles({
@@ -55,22 +55,14 @@ const useStyles = makeStyles({
 })
 
 export default () => {
-    const userId = useSelector(AuthSelectors.getUserId)
-    const idToken = useSelector(AuthSelectors.getIdToken)
     const organizerEvents = useSelector(UserSelectors.organizerEvents)
     const classes = useStyles()
 
     const dispatch = useDispatch()
     const { t } = useTranslation()
-    var date = new Date()
-    const isodate = date.toISOString()
 
     const [searchTerm, setSearchTerm] = useState('')
-    const [searchResults, setSearchResults] = useState(organizerEvents)
-    const [name, setName] = useState('')
-    const [error, setError] = useState()
-    const [loading, setLoading] = useState(false)
-    const hasError = Boolean(error)
+    const [searchResults, setSearchResults] = useState([])
 
     const isOrganizer = useSelector(AuthSelectors.idTokenData)?.roles?.some(r =>
         ['Organiser', 'AssistantOrganiser', 'SuperAdmin'].includes(r),
@@ -78,17 +70,32 @@ export default () => {
 
     //TODO implement pagination to improve performance of organize tab
 
+    let searchTermDebounced = useDebounce(searchTerm, 1000)
+
     useEffect(() => {
-        const results = organizerEvents.filter(
-            event =>
-                event.name.toLowerCase().indexOf(searchTerm.toLowerCase()) !==
-                -1,
-        )
-        setSearchResults(results)
-    }, [organizerEvents, searchTerm])
+        if (
+            organizerEvents &&
+            Array.isArray(organizerEvents) &&
+            organizerEvents.length > 0
+        ) {
+            if (searchTermDebounced) {
+                const results = organizerEvents.filter(
+                    event =>
+                        event.name
+                            .toLowerCase()
+                            .indexOf(searchTermDebounced.toLowerCase()) !== -1,
+                )
+                setSearchResults(results)
+            } else {
+                setSearchResults(organizerEvents)
+            }
+        }
+    }, [organizerEvents, searchTermDebounced])
 
     //TODO: super slow on superadmin. fix the rendering
-    return organizerEvents.length === 0 || !isOrganizer ? (
+    return searchResults &&
+        Array.isArray(searchResults) &&
+        (searchResults.length === 0 || !isOrganizer) ? (
         <>
             <PageHeader
                 heading="Your Admin Events"

--- a/frontend/src/pages/_dashboard/renderDashboard/default/events/Participant.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/default/events/Participant.js
@@ -49,7 +49,12 @@ export default () => {
                         </Grid>
 
                         {registrations?.map((registration, index) => (
-                            <Grid key={`${registration.id}-${index}`} item xs={12} md={6}>
+                            <Grid
+                                key={`${registration.id}-${index}`}
+                                item
+                                xs={12}
+                                md={6}
+                            >
                                 <EventCardSmall
                                     key={index}
                                     event={registration.event}
@@ -90,6 +95,7 @@ export default () => {
                                 const eventStarted = isodate > event.startTime
                                 return (
                                     <NewEventCard
+                                        key={`active-${event._id}`}
                                         event={event}
                                         buttons={[
                                             <Button
@@ -156,6 +162,7 @@ export default () => {
                             const eventStarted = isodate > event.startTime
                             return (
                                 <NewEventCard
+                                    key={`past-${event._id}`}
                                     event={event}
                                     buttons={[
                                         <Button

--- a/frontend/src/pages/_dashboard/renderDashboard/default/events/Partner.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/default/events/Partner.js
@@ -65,7 +65,7 @@ export default () => {
                             //TODO: fiter current event away
 
                             return (
-                                <Grid item xs={12}>
+                                <Grid key={`partner-${event._id}`} item xs={12}>
                                     <NewEventCard
                                         event={event}
                                         buttons={[

--- a/frontend/src/pages/_dashboard/renderDashboard/default/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/default/index.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useRouteMatch, useLocation } from 'react-router'
 // import { push } from 'connected-react-router'
-import { useDispatch, useSelector } from 'react-redux'
+// import { useDispatch, useSelector } from 'react-redux'
 // import { makeStyles } from '@material-ui/core/styles'
 
 import SidebarLayout from 'components/layouts/SidebarLayout' //TODO: make normal sidepar work with default view
@@ -11,125 +11,111 @@ import PageWrapper from 'components/layouts/PageWrapper'
 import defaultImage from 'assets/images/dashboardDefault.jpg'
 
 // import * as DashboardSelectors from 'redux/dashboard/selectors'
-import * as DashboardActions from 'redux/dashboard/actions'
-import * as AuthSelectors from 'redux/auth/selectors'
-import * as UserSelectors from 'redux/user/selectors'
-import * as UserActions from 'redux/user/actions'
+// import * as DashboardActions from 'redux/dashboard/actions'
+// import * as AuthSelectors from 'redux/auth/selectors'
+// import * as UserSelectors from 'redux/user/selectors'
+// import * as UserActions from 'redux/user/actions'
 
-import { useTranslation } from 'react-i18next'
-import {
-    useMyEvents,
-    useActiveEvents,
-    usePastEvents,
-} from 'graphql/queries/events'
+// import { useTranslation } from 'react-i18next'
+// import {
+//     useMyEvents,
+//     useActiveEvents,
+//     usePastEvents,
+// } from 'graphql/queries/events'
 // import { Chat } from 'components/messaging/chat'
-
-// const useStyles = makeStyles(theme => ({
-//     sidebarTop: {
-//         padding: theme.spacing(3),
-//         height: '100%',
-//         display: 'flex',
-//         flexDirection: 'column',
-//         alignItems: 'center',
-//         justifyContent: 'center',
-//     },
-//     sidebarLogo: {
-//         width: '100%',
-//         objectFit: 'contain',
-//     },
-// }))
 
 export default () => {
     // const classes = useStyles()
     const match = useRouteMatch()
     const location = useLocation()
 
-    const dispatch = useDispatch()
+    // const dispatch = useDispatch()
 
-    const recruiterEvents = useSelector(
-        UserSelectors.userProfileRecruiterEvents,
-    )
-    const [organizerEvents, loadingEvents] = useMyEvents() //TODO: move to user state
-    const participantEvents = useSelector(
-        UserSelectors.userProfileRegistrations,
-    )
-    const [activeEvents, loadingActive] = useActiveEvents({}) //active events, from these we select where to rediret, or default
-    const [pastEvents, loadingPast] = usePastEvents({ limit: 3 }) //TODO: is undefined, fix
-    const [loading, setLoading] = useState(true)
+    // const recruiterEvents = useSelector(
+    //     UserSelectors.userProfileRecruiterEvents,
+    // )
+    // const [organizerEvents, loadingEvents] = useMyEvents() //TODO: move to user state
+    // const participantEvents = useSelector(
+    //     UserSelectors.userProfileRegistrations,
+    // )
+    // const [activeEvents, loadingActive] = useActiveEvents({}) //active events, from these we select where to rediret, or default
+    // const [pastEvents, loadingPast] = usePastEvents({ limit: 3 }) //TODO: is undefined, fix
+    // const [loading, setLoading] = useState(true)
 
-    useEffect(() => {
-        dispatch(UserActions.organizerEvents(organizerEvents))
-        if (!loadingActive) {
-            dispatch(DashboardActions.activeEvents(activeEvents))
-        }
-        if (!loadingPast) {
-            dispatch(DashboardActions.pastEvents(pastEvents))
-        }
-        if (!(loadingActive || loadingEvents || loadingPast)) {
-            setLoading(false)
-        }
-    }, [organizerEvents, activeEvents, pastEvents])
+    // useEffect(() => {
 
-    const isPartner = useSelector(AuthSelectors.idTokenData)?.roles?.includes(
-        'Recruiter',
-    )
+    //     dispatch(UserActions.organizerEvents(organizerEvents))
+    //     if (!loadingActive) {
+    //         dispatch(DashboardActions.activeEvents(activeEvents))
+    //     }
+    //     if (!loadingPast) {
+    //         dispatch(DashboardActions.pastEvents(pastEvents))
+    //     }
+    //     if (!(loadingActive || loadingEvents || loadingPast)) {
+    //         setLoading(false)
+    //     }
+    // }, [organizerEvents, activeEvents, pastEvents])
 
-    const isOrganizer = useSelector(AuthSelectors.idTokenData)?.roles?.some(r =>
-        ['Organiser', 'AssistantOrganiser', 'SuperAdmin'].includes(r),
-    )
+    // const isPartner = useSelector(AuthSelectors.idTokenData)?.roles?.includes(
+    //     'Recruiter',
+    // )
 
-    let page = ''
-    let accessRight = ''
+    // const isOrganizer = useSelector(AuthSelectors.idTokenData)?.roles?.some(r =>
+    //     ['Organiser', 'AssistantOrganiser', 'SuperAdmin'].includes(r),
+    // )
 
-    useEffect(() => {
-        if (page === '') {
-            const partnerPage = activeEvents?.find(active =>
-                recruiterEvents?.some(e => e.eventId === active._id),
-            )?.slug
+    // let page = ''
+    // let accessRight = ''
 
-            if (partnerPage && isPartner) {
-                page = partnerPage
-                accessRight = 'partner'
-            }
-        }
+    // useEffect(() => {
+    //     if (page === '') {
+    //         const partnerPage = activeEvents?.find(active =>
+    //             recruiterEvents?.some(e => e.eventId === active._id),
+    //         )?.slug
 
-        if (page === '') {
-            const orgPage = activeEvents?.find(active =>
-                organizerEvents?.some(e => e._id === active._id),
-            )?.slug
+    //         if (partnerPage && isPartner) {
+    //             page = partnerPage
+    //             accessRight = 'partner'
+    //         }
+    //     }
 
-            if (orgPage && isOrganizer) {
-                page = orgPage
-                accessRight = 'organizer'
-            }
-        }
+    //     if (page === '') {
+    //         const orgPage = activeEvents?.find(active =>
+    //             organizerEvents?.some(e => e._id === active._id),
+    //         )?.slug
 
-        if (page === '') {
-            const participantPage = activeEvents?.find(active => {
-                return participantEvents?.some(e => e.event === active._id)
-            })?.slug
+    //         if (orgPage && isOrganizer) {
+    //             page = orgPage
+    //             accessRight = 'organizer'
+    //         }
+    //     }
 
-            if (participantPage) {
-                page = participantPage
-                accessRight = 'participant'
-            }
-        }
+    //     if (page === '') {
+    //         const participantPage = activeEvents?.find(active => {
+    //             return participantEvents?.some(e => e.event === active._id)
+    //         })?.slug
 
-        if (page !== '' && accessRight !== '') {
-        }
-    }, [loading])
+    //         if (participantPage) {
+    //             page = participantPage
+    //             accessRight = 'participant'
+    //         }
+    //     }
 
-    const { t } = useTranslation()
+    //     if (page !== '' && accessRight !== '') {
+    //     }
+    // }, [loading])
+
+    // const { t } = useTranslation()
 
     return (
-        <PageWrapper wrapContent={false} loading={loadingActive || loadingPast}>
+        <PageWrapper wrapContent={false}>
             <SidebarLayout
                 baseRoute={match.url}
                 location={location}
                 sidebarTopContent={
                     <img src={defaultImage} width={250} height={250}></img>
                 }
-                topContent={<BasicNavBar text={''} />}
+                topContent={<BasicNavBar />}
                 routes={[]}
             />
         </PageWrapper>

--- a/frontend/src/pages/_dashboard/renderDashboard/default/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/default/index.js
@@ -1,111 +1,15 @@
 import React from 'react'
 
 import { useRouteMatch, useLocation } from 'react-router'
-// import { push } from 'connected-react-router'
-// import { useDispatch, useSelector } from 'react-redux'
-// import { makeStyles } from '@material-ui/core/styles'
 
 import SidebarLayout from 'components/layouts/SidebarLayout' //TODO: make normal sidepar work with default view
 import BasicNavBar from 'components/navbars/BasicNavBar'
 import PageWrapper from 'components/layouts/PageWrapper'
 import defaultImage from 'assets/images/dashboardDefault.jpg'
 
-// import * as DashboardSelectors from 'redux/dashboard/selectors'
-// import * as DashboardActions from 'redux/dashboard/actions'
-// import * as AuthSelectors from 'redux/auth/selectors'
-// import * as UserSelectors from 'redux/user/selectors'
-// import * as UserActions from 'redux/user/actions'
-
-// import { useTranslation } from 'react-i18next'
-// import {
-//     useMyEvents,
-//     useActiveEvents,
-//     usePastEvents,
-// } from 'graphql/queries/events'
-// import { Chat } from 'components/messaging/chat'
-
 export default () => {
-    // const classes = useStyles()
     const match = useRouteMatch()
     const location = useLocation()
-
-    // const dispatch = useDispatch()
-
-    // const recruiterEvents = useSelector(
-    //     UserSelectors.userProfileRecruiterEvents,
-    // )
-    // const [organizerEvents, loadingEvents] = useMyEvents() //TODO: move to user state
-    // const participantEvents = useSelector(
-    //     UserSelectors.userProfileRegistrations,
-    // )
-    // const [activeEvents, loadingActive] = useActiveEvents({}) //active events, from these we select where to rediret, or default
-    // const [pastEvents, loadingPast] = usePastEvents({ limit: 3 }) //TODO: is undefined, fix
-    // const [loading, setLoading] = useState(true)
-
-    // useEffect(() => {
-
-    //     dispatch(UserActions.organizerEvents(organizerEvents))
-    //     if (!loadingActive) {
-    //         dispatch(DashboardActions.activeEvents(activeEvents))
-    //     }
-    //     if (!loadingPast) {
-    //         dispatch(DashboardActions.pastEvents(pastEvents))
-    //     }
-    //     if (!(loadingActive || loadingEvents || loadingPast)) {
-    //         setLoading(false)
-    //     }
-    // }, [organizerEvents, activeEvents, pastEvents])
-
-    // const isPartner = useSelector(AuthSelectors.idTokenData)?.roles?.includes(
-    //     'Recruiter',
-    // )
-
-    // const isOrganizer = useSelector(AuthSelectors.idTokenData)?.roles?.some(r =>
-    //     ['Organiser', 'AssistantOrganiser', 'SuperAdmin'].includes(r),
-    // )
-
-    // let page = ''
-    // let accessRight = ''
-
-    // useEffect(() => {
-    //     if (page === '') {
-    //         const partnerPage = activeEvents?.find(active =>
-    //             recruiterEvents?.some(e => e.eventId === active._id),
-    //         )?.slug
-
-    //         if (partnerPage && isPartner) {
-    //             page = partnerPage
-    //             accessRight = 'partner'
-    //         }
-    //     }
-
-    //     if (page === '') {
-    //         const orgPage = activeEvents?.find(active =>
-    //             organizerEvents?.some(e => e._id === active._id),
-    //         )?.slug
-
-    //         if (orgPage && isOrganizer) {
-    //             page = orgPage
-    //             accessRight = 'organizer'
-    //         }
-    //     }
-
-    //     if (page === '') {
-    //         const participantPage = activeEvents?.find(active => {
-    //             return participantEvents?.some(e => e.event === active._id)
-    //         })?.slug
-
-    //         if (participantPage) {
-    //             page = participantPage
-    //             accessRight = 'participant'
-    //         }
-    //     }
-
-    //     if (page !== '' && accessRight !== '') {
-    //     }
-    // }, [loading])
-
-    // const { t } = useTranslation()
 
     return (
         <PageWrapper wrapContent={false}>

--- a/frontend/src/pages/_dashboard/renderDashboard/generalPages/default/Blocks/AlertBlock.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/generalPages/default/Blocks/AlertBlock.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid, Typography } from '@material-ui/core'
+import { Typography } from '@material-ui/core'
 import GradientBox from 'components/generic/GradientBox'
 import { Alerts } from '../../../../../../components/messaging/alerts'
 import TimeLineBlock from '../Blocks/TimeLineBlock'
@@ -10,10 +10,6 @@ const makeBoxStyles = () => ({
     border: `2px solid #e2e8f0`,
     borderRadius: '6px',
     height: '100%',
-
-    //TODO: blurr the bottom
-
-    // backgroundColor: '#f8f8f8',
 })
 
 const makeTimelineStyles = () => ({
@@ -23,8 +19,6 @@ const makeTimelineStyles = () => ({
     height: '100%',
 
     overflow: 'auto',
-
-    // backgroundColor: '#f8f8f8',
 })
 
 export default ({ alerts = [] }) => {
@@ -32,13 +26,6 @@ export default ({ alerts = [] }) => {
     return (
         <>
             {alerts && alerts.length > 0 && (
-                // <Grid
-                //     direction="column"
-                //     alignItems="stretch"
-                //     item
-                //     xs={8}
-                //     style={{ marginLeft: '20px', marginRight: '20px' }}
-                // >
                 <GradientBox style={makeBoxStyles()} color="theme_white" p={3}>
                     <Typography variant="button" gutterBottom>
                         {t('Announcements_')}
@@ -46,9 +33,7 @@ export default ({ alerts = [] }) => {
                     <hr className="tw-h-px  tw-bg-gray-500 tw-border-0 tw-dark:bg-gray-900"></hr>
                     <Alerts alerts={alerts} />
                 </GradientBox>
-                // </Grid>
             )}
-            {/* <Grid item xs={alerts && alerts.length > 0 ? 4 : 12}> */}
             <GradientBox style={makeTimelineStyles()} color="theme_white" p={3}>
                 <Typography variant="button" gutterBottom>
                     {t('Event_timeline_')}
@@ -56,7 +41,6 @@ export default ({ alerts = [] }) => {
                 <hr className="tw-h-px  tw-bg-gray-500 tw-border-0 tw-dark:bg-gray-900"></hr>
                 <TimeLineBlock />
             </GradientBox>
-            {/* </Grid> */}
         </>
     )
 }

--- a/frontend/src/pages/_dashboard/renderDashboard/generalPages/default/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/generalPages/default/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Grid } from '@material-ui/core'
+import { Box } from '@material-ui/core'
 import PageHeader from 'components/generic/PageHeader'
 import { Helmet } from 'react-helmet'
 import config from 'constants/config'
@@ -8,7 +8,7 @@ import ProjectBlock from './Blocks/ProjectBlock'
 import TeamStatusBlock from './Blocks/TeamStatusBlock'
 // import VisaInvitationBlock from './Blocks/VisaInvitationBlock'
 // import TravelGrantStatusBlock from './Blocks/TravelGrantStatusBlock'
-import GavelReviewingBlock from './Blocks/GavelReviewingBlock'
+// import GavelReviewingBlock from './Blocks/GavelReviewingBlock'
 import ProjectSubmissionsBlock from './Blocks/ProjectSubmissionsBlock'
 import ReviewingPeriodBlock from './Blocks/ReviewingPeriodBlock'
 import CertificateBlock from './Blocks/CertificateBlock'
@@ -68,15 +68,6 @@ export default ({ alerts }) => {
                     content={config.SEO_TWITTER_HANDLE}
                 />
             </Helmet>
-            {/* <Grid container spacing={5}>
-                <div
-                    style={{
-                        height: '400px',
-                        width: '100%',
-                        display: 'flex',
-                        padding: '2em',
-                    }}
-                ></div> */}
             <AlertBlock alerts={alerts} />
 
             <EventOverBlock />

--- a/frontend/src/pages/_dashboard/renderDashboard/organiser/default/EventsList.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/organiser/default/EventsList.js
@@ -75,7 +75,7 @@ export default ({ events = [] }) => {
             <Grid
                 container
                 direction="row"
-                justify="flex-start"
+                justifyContent="flex-start"
                 alignItems="center"
                 spacing={1}
             >

--- a/frontend/src/pages/_dashboard/renderDashboard/organiser/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/organiser/index.js
@@ -6,7 +6,7 @@ import { Typography, Box } from '@material-ui/core'
 import { EventTypes } from '@hackjunction/shared'
 import TuneIcon from '@material-ui/icons/Tune'
 import SettingsIcon from '@material-ui/icons/Settings'
-import EqualizerIcon from '@material-ui/icons/Equalizer'
+// import EqualizerIcon from '@material-ui/icons/Equalizer'
 import PeopleIcon from '@material-ui/icons/People'
 import CropFreeIcon from '@material-ui/icons/CropFree'
 import CodeIcon from '@material-ui/icons/Code'
@@ -51,22 +51,10 @@ export default () => {
 
     useEffect(() => {
         if (event) {
-            // dispatch(
-            //     OrganiserActions.updateOrganisersForEvent(
-            //         event.owner,
-            //         event.organisers,
-            //     ),
-            // )
             dispatch(
                 OrganiserActions.updateRecruitersForEvent(event.recruiters),
             )
-            // dispatch(OrganiserActions.updateRegistrationsForEvent(slug))
-            // dispatch(OrganiserActions.updateTeamsForEvent(slug))
             dispatch(OrganiserActions.updateFilterGroups(slug))
-            // dispatch(OrganiserActions.updateProjects(slug))
-            // dispatch(OrganiserActions.updateGavelProjects(slug))
-            // dispatch(OrganiserActions.updateRankings(slug))
-            // dispatch(OrganiserActions.generateResults(slug)) // TODO do we need to get results always?
         }
     }, [dispatch, slug, event])
     return (
@@ -110,14 +98,10 @@ export default () => {
                                     zIndex: 100,
                                 }}
                             >
-                                <>
-                                    The event will be published once approved by
-                                    admins. Questions about the approval process
-                                    can be directed to hello@hackjunction.com
-                                </>
+                                {t('Event_waiting_approval_')}
                             </Alert>
                         ) : null}
-                        <BasicNavBar text={event.name} />
+                        <BasicNavBar />
                     </>
                 }
                 baseRoute={match.url}

--- a/frontend/src/pages/_dashboard/renderDashboard/organiser/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/organiser/index.js
@@ -107,6 +107,7 @@ export default () => {
                 baseRoute={match.url}
                 location={location}
                 routes={[
+                    // TODO make one of the routes default or create a default route to render, instead of the events page
                     {
                         key: 'edit',
                         path: '/edit',
@@ -116,9 +117,9 @@ export default () => {
                     },
                     // {
                     //     key: 'stats',
-                    //     path: '/stats',
+                    //     path: '/',
                     //     exact: true,
-                    //     icon: <EqualizerIcon />,
+                    //     // icon: <EqualizerIcon />,
                     //     label: 'Stats',
                     //     component: StatsPage,
                     // },

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/index.js
@@ -45,6 +45,8 @@ import {
 
 import { Chat } from 'components/messaging/chat'
 import { Grid, Paper } from '@material-ui/core'
+import DefaultImage from 'assets/images/dashboardDefault.jpg'
+import { debugGroup } from 'utils/debuggingTools'
 
 const useStyles = makeStyles(theme => ({
     sidebarTop: {
@@ -78,6 +80,7 @@ export default ({
     useEffect(() => {
         setAlerts(originalAlerts)
         setAlertCount(originalAlertCount)
+        debugGroup('Dashboard alerts', [originalAlerts, originalAlertCount])
     }, [originalAlerts, originalAlertCount])
 
     return (
@@ -88,12 +91,11 @@ export default ({
                 <div className={classes.sidebarTop}>
                     <Image
                         className={classes.sidebarLogo}
-                        publicId={
-                            event && event.logo ? event.logo.publicId : '' //TODO: if no logo, use default
-                        }
+                        publicId={event && event.logo && event.logo.publicId}
                         transformation={{
                             width: 200,
                         }}
+                        defaultImage={DefaultImage}
                     />
                 </div>
             }

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/index.js
@@ -46,7 +46,6 @@ import {
 import { Chat } from 'components/messaging/chat'
 import { Grid, Paper } from '@material-ui/core'
 import DefaultImage from 'assets/images/dashboardDefault.jpg'
-import { debugGroup } from 'utils/debuggingTools'
 
 const useStyles = makeStyles(theme => ({
     sidebarTop: {
@@ -80,7 +79,6 @@ export default ({
     useEffect(() => {
         setAlerts(originalAlerts)
         setAlertCount(originalAlertCount)
-        debugGroup('Dashboard alerts', [originalAlerts, originalAlertCount])
     }, [originalAlerts, originalAlertCount])
 
     return (

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/CompareProjects.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/CompareProjects.js
@@ -164,7 +164,7 @@ export default ({ annotator, prevId, nextId, isFirstChoice }) => {
         }
 
         return (
-            <Grid container spacing={3} direction="row" justify="center">
+            <Grid container spacing={3} direction="row" justifyContent="center">
                 <ProjectsGridItem
                     project={projects.prev.project}
                     event={event}

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/Complete.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/Complete.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
 export default () => {
     const classes = useStyles()
     return (
-        <Grid container spacing={3} direction="row" justify="center">
+        <Grid container spacing={3} direction="row" justifyContent="center">
             <Grid item xs={12} md={8}>
                 <Box
                     p={3}

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/Disabled.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/reviewing/Disabled.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
 export default () => {
     const classes = useStyles()
     return (
-        <Grid container spacing={3} direction="row" justify="center">
+        <Grid container spacing={3} direction="row" justifyContent="center">
             <Grid item xs={12} md={8}>
                 <Box
                     p={3}

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useRouteMatch, useLocation } from 'react-router'
 import RateReviewIcon from '@material-ui/icons/RateReview'
+import WorkIcon from '@material-ui/icons/Work'
 import { makeStyles } from '@material-ui/core/styles'
 import {
     // Hidden,
@@ -15,6 +16,7 @@ import DefaultImage from 'assets/images/dashboardDefault.jpg'
 import Image from 'components/generic/Image'
 
 import ProjectsPage from './projects'
+import RecruitmentPage from './partnerrecruitment'
 import { useTranslation } from 'react-i18next'
 
 const useStyles = makeStyles(theme => ({
@@ -42,8 +44,6 @@ export default ({
     const classes = useStyles()
     const match = useRouteMatch()
     const location = useLocation()
-    // const [alertCount, setAlertCount] = useState(originalAlertCount)
-    // const [alerts, setAlerts] = useState(originalAlerts)
     const { t } = useTranslation()
 
     return (
@@ -54,9 +54,7 @@ export default ({
                 <div className={classes.sidebarTop}>
                     <Image
                         className={classes.sidebarLogo}
-                        // publicId={
-                        //     event && event.logo ? event.logo.publicId : ''
-                        // }
+                        publicId={event && event.logo && event.logo.publicId}
                         transformation={{
                             width: 200,
                         }}
@@ -74,31 +72,19 @@ export default ({
                     path: '',
                     exact: true,
                     icon: <RateReviewIcon />,
-                    // icon: (
-                    //     <Badge badgeContent={alertCount} color="primary">
-                    //         <DashboardIcon />
-                    //     </Badge>
-                    // ),
                     label: t('Review_projects_'),
                     component: () => {
                         return <ProjectsPage event={event} />
-                        // return DefaultPage({ alerts })
                     },
                 },
-                //TODO enable talent matchmaking
-                // {
-                //     key: 'Review',
-                //     path: '/review',
-                //     // hidden: !shownPages?.reviewingByScoreCriteria,
-                //     locked: lockedPages.reviewing,
-                //     lockedDescription: 'Reviewing closed',
-                //     exact: false,
-                //     icon: <RateReviewIcon />,
-                //     label: t('Review_projects_'),
-                //     component: () => {
-                //         return <ProjectsPage event={event} />
-                //     },
-                // },
+                {
+                    key: 'recruitment',
+                    path: '/recruitment',
+                    exact: false,
+                    icon: <WorkIcon />,
+                    label: 'Recruitment',
+                    component: RecruitmentPage,
+                },
                 // TODO rework meetings, consider using rally.co
                 // {
                 //     key: 'meetings',
@@ -119,17 +105,6 @@ export default ({
                 //     component: HackerpackPage,
                 // },
                 //Experimental
-                // {
-                //     key: 'recruitment',
-                //     path: '/recruitment',
-                //     exact: false,
-                //     icon: <WorkIcon />,
-                //     label: 'Recruitment',
-                //     component: RecruitmentPage,
-                //     Hidden: !shownPages?.experimental,
-                //     locked: true,
-                //     lockedDescription: 'Currently unavailable',
-                // },
                 // {
                 //     key: 'map',
                 //     path: '/map',

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/Filters/FilteredBy.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/Filters/FilteredBy.js
@@ -96,7 +96,7 @@ export default () => {
             ) : null}
             {Array.isArray(spokenLanguages) && spokenLanguages.length ? (
                 <FilteredByItem
-                    label={t('Spoken_languages')}
+                    label={t('Spoken_languages_')}
                     text={spokenLanguages.join(', ')}
                 />
             ) : null}

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/Filters/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/Filters/index.js
@@ -1,7 +1,11 @@
 import React, { useState, useCallback, useEffect } from 'react'
 
-import { Box, CircularProgress, Grid } from '@material-ui/core'
-import SearchIcon from '@material-ui/icons/Search'
+import {
+    Box,
+    // CircularProgress,
+    Grid,
+} from '@material-ui/core'
+// import SearchIcon from '@material-ui/icons/Search'
 import { motion } from 'framer-motion'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -18,7 +22,7 @@ import SkillsFilter from './SkillsFilter'
 import RolesFilter from './RolesFilter'
 import FilteredBy from './FilteredBy'
 import LoadingCard from '../SearchResults/LoadingCard'
-import TextInput from 'components/inputs/TextInput'
+// import TextInput from 'components/inputs/TextInput'
 
 export default () => {
     const dispatch = useDispatch()
@@ -68,8 +72,7 @@ export default () => {
 
     return (
         <Box display="flex" flexDirection="column">
-
-            <Box
+            {/* <Box
                 display="flex"
                 flexDirection="row"
                 alignItems="center"
@@ -84,7 +87,7 @@ export default () => {
                     />
                 </Box>
 
-            </Box>
+            </Box> */}
             <motion.div
                 animate={{
                     overflow: 'hidden',
@@ -110,7 +113,7 @@ export default () => {
                     <FilteredBy />
                 </Box>
             </motion.div>
-            {loading && (renderLoading())}
+            {loading && renderLoading()}
         </Box>
     )
 }

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/ResultCard.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/ResultCard.js
@@ -119,7 +119,9 @@ export default React.memo(
                 ).then(({ error }) => {
                     if (error) {
                         dispatch(
-                            SnackbarActions.error('Something went wrong...'),
+                            SnackbarActions.error(
+                                'Something went wrong, please refresh the page and try again',
+                            ),
                         )
                         setIsFavorite(_isFavorite)
                     }

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/ResultCard.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/ResultCard.js
@@ -1,8 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react'
-import { useRouteMatch } from 'react-router'
 import { useDispatch, useSelector } from 'react-redux'
 import { findIndex } from 'lodash-es'
-import { push } from 'connected-react-router'
 import {
     Avatar,
     Paper,
@@ -89,7 +87,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default React.memo(
-    ({ data, organisation }) => {
+    ({ data, organisation, onClick = () => {}, eventId }) => {
         const dispatch = useDispatch()
         const actionHistoryByUser = useSelector(
             RecruitmentSelectors.actionHistoryByUser,
@@ -101,8 +99,6 @@ export default React.memo(
         // Toggle the favorited state locally for immediate feedback on favorite action
         const [_isFavorite, setIsFavorite] = useState(isFavorite)
         const classes = useStyles({ isFavorite: _isFavorite })
-        const match = useRouteMatch()
-        const baseRoute = match.url
 
         useEffect(() => {
             setIsFavorite(isFavorite)
@@ -118,6 +114,7 @@ export default React.memo(
                         data.userId,
                         _isFavorite,
                         organisation,
+                        eventId,
                     ),
                 ).then(({ error }) => {
                     if (error) {
@@ -132,12 +129,7 @@ export default React.memo(
         )
 
         return (
-            <Paper
-                className={classes.root}
-                onClick={() => {
-                    dispatch(push(`${baseRoute}/${data.userId}`))
-                }}
-            >
+            <Paper className={classes.root} onClick={onClick}>
                 <Box className={classes.iconRight}>
                     <Tooltip
                         title={
@@ -152,18 +144,16 @@ export default React.memo(
                     </Tooltip>
                 </Box>
                 <div style={{ flex: 1 }}>
-                    {data.profile.avatar && (
-                        <Avatar
-                            className={classes.avatar}
-                            alt="Profile Picture"
-                            src={data.profile.avatar}
-                            imgProps={{
-                                onError: e => {
-                                    e.target.src = emblem_black
-                                },
-                            }}
-                        />
-                    )}
+                    <Avatar
+                        className={classes.avatar}
+                        alt="Profile Picture"
+                        src={data.profile.avatar}
+                        imgProps={{
+                            onError: e => {
+                                e.target.src = emblem_black
+                            },
+                        }}
+                    />
                     <Box className={classes.topWrapper} mb={1}>
                         <Typography className={classes.name} variant="h6">
                             {data.profile.firstName} {data.profile.lastName}

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/SearchResults/index.js
@@ -2,22 +2,23 @@ import React, { useEffect } from 'react'
 import Empty from 'components/generic/Empty'
 import ResultCard from './ResultCard'
 import { useDispatch, useSelector } from 'react-redux'
-// import { useRouteMatch } from 'react-router'
-import { Grid, Box, Typography, CircularProgress } from '@material-ui/core'
+import { useRouteMatch } from 'react-router'
+import { Grid, Box, Typography } from '@material-ui/core'
 
 import * as RecruitmentSelectors from 'redux/recruitment/selectors'
 import * as RecruitmentActions from 'redux/recruitment/actions'
-import * as DashboardActions from 'redux/dashboard/actions'
+// import * as DashboardActions from 'redux/dashboard/actions'
 import { useTranslation } from 'react-i18next'
 import Pagination from './Pagination'
 import LoadingCard from './LoadingCard'
-import { debugGroup } from 'utils/debuggingTools'
+import { push } from 'connected-react-router'
 
-export default ({ items, organisation }) => {
+export default ({ items, organisation, eventId }) => {
     const dispatch = useDispatch()
-    // const match = useRouteMatch()
-    const searchResults =
-        items ?? useSelector(RecruitmentSelectors.searchResults)
+    const match = useRouteMatch()
+    const baseRoute = match.url
+    const itemsFromStore = useSelector(RecruitmentSelectors.searchResults)
+    const searchResults = items ?? itemsFromStore
     const searchResultsCount = useSelector(
         RecruitmentSelectors.searchResultsCount,
     )
@@ -27,14 +28,8 @@ export default ({ items, organisation }) => {
     const page = useSelector(RecruitmentSelectors.page)
     const paginationEnabled = !items
     const isFavorited = !!items
-    // const { slug } = match.params
+    // // const { slug } = match.params
     const { t } = useTranslation()
-
-    debugGroup('RecruitmentSearchResults', [
-        useSelector(RecruitmentSelectors.searchResults),
-        searchResults,
-        searchResultsCount,
-    ])
 
     useEffect(() => {
         //dispatch(DashboardActions.updateEvent(slug))
@@ -43,7 +38,7 @@ export default ({ items, organisation }) => {
 
     const renderLoading = () => {
         if (!loading) return null
-        if (searchResults.length === 0) {
+        if (Array.isArray(searchResults) && searchResults.length === 0) {
             return (
                 <>
                     <Grid container spacing={2}>
@@ -57,7 +52,6 @@ export default ({ items, organisation }) => {
                                 xs={12}
                                 sm={6}
                                 md={4}
-                                //lg={3}
                             >
                                 <LoadingCard />
                             </Grid>
@@ -70,9 +64,13 @@ export default ({ items, organisation }) => {
     }
 
     const renderResults = () => {
-        if (searchResults.length === 0 && !loading) {
+        if (
+            Array.isArray(searchResults) &&
+            searchResults.length === 0 &&
+            !loading
+        ) {
             if (isFavorited) {
-                return <Empty isEmpty emptyText={t('No_favorites')} />
+                return <Empty isEmpty emptyText={t('No_favorites_')} />
             } else if (filters.textSearch) {
                 return <Empty isEmpty emptyText={t('No_results_')} />
             } else {
@@ -81,21 +79,30 @@ export default ({ items, organisation }) => {
         }
         return (
             <Grid direction="row" alignItems="stretch" container spacing={2}>
-                {searchResults.map(user => (
-                    <Grid
-                        direction="row"
-                        alignItems="stretch"
-                        container
-                        key={`item-${user.userId}`}
-                        item
-                        xs={12}
-                        sm={6}
-                        md={4}
-                        //lg={3}
-                    >
-                        <ResultCard data={user} organisation={organisation} />
-                    </Grid>
-                ))}
+                {Array.isArray(searchResults) &&
+                    searchResults.map(user => (
+                        <Grid
+                            direction="row"
+                            alignItems="stretch"
+                            container
+                            key={`item-${user.userId}`}
+                            item
+                            xs={12}
+                            sm={6}
+                            md={4}
+                        >
+                            <ResultCard
+                                data={user}
+                                organisation={organisation}
+                                onClick={() => {
+                                    dispatch(
+                                        push(`${baseRoute}/${user.userId}`),
+                                    )
+                                }}
+                                eventId={eventId}
+                            />
+                        </Grid>
+                    ))}
             </Grid>
         )
     }

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/ToggleFavorites.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/ToggleFavorites.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { makeStyles } from '@material-ui/core/styles'
-import { Button as MuiButton, Badge } from '@material-ui/core'
+import { Badge } from '@material-ui/core'
 import Button from 'components/generic/Button'
 
 const useStyles = makeStyles(theme => ({
@@ -14,7 +14,11 @@ const ToggleFavorites = ({ count, active, onChange }) => {
     const classes = useStyles()
     return (
         <Badge badgeContent={!active ? count : 0} color="secondary">
-            <Button variant={'contained'} onClick={onChange} className={classes.padding}>
+            <Button
+                variant={'contained'}
+                onClick={onChange}
+                className={classes.padding}
+            >
                 {active ? 'Back to search' : 'Your favorites'}
             </Button>
         </Badge>

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/default/index.js
@@ -65,7 +65,7 @@ export default () => {
         SetRecruiterOrganisation(organisation)
 
         dispatch(RecruitmentActions.updateActionHistory(organisation))
-    }, [dispatch])
+    }, [recEvents])
 
     return (
         <>

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/id/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/id/index.js
@@ -6,42 +6,17 @@ import { Dialog } from '@material-ui/core'
 
 import PageWrapper from 'components/layouts/PageWrapper'
 
-import UserProfilesService from 'services/userProfiles'
-
 import * as AuthSelectors from 'redux/auth/selectors'
 import Profile from 'components/Participant/Profile'
 import RecruitmentFavorites from 'components/Participant/RecruitmentFavorites'
-
-const useStyles = makeStyles(theme => ({
-    iconBlue: {
-        backgroundColor: theme.palette.theme_turquoise.main,
-        width: '20px',
-        height: '20px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRadius: '50%',
-        marginRight: '8px',
-    },
-    iconPurple: {
-        backgroundColor: theme.palette.theme_purple.main,
-        width: '20px',
-        height: '20px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRadius: '50%',
-        marginRight: '8px',
-    },
-    bold: {
-        fontWeight: 'bold',
-    },
-}))
+import RecruitmentService from 'services/recruitment'
+import * as DashboardSelectors from 'redux/dashboard/selectors'
 
 export default () => {
     const idToken = useSelector(AuthSelectors.getIdToken)
     const match = useRouteMatch()
-
+    const event = useSelector(DashboardSelectors.event)
+    const eventId = event._id
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState(false)
     const [user, setUser] = useState(null)
@@ -51,16 +26,20 @@ export default () => {
         if (id) {
             setLoading(true)
 
-            UserProfilesService.getUserProfileRecruitment(id, idToken)
+            RecruitmentService.getUserProfile(idToken, id, eventId)
                 .then(data => {
                     setUser(data)
                 })
                 .catch(err => {
+                    console.error('FROM PROFILE RENDER', err)
                     setError(true)
                 })
                 .finally(() => {
                     setLoading(false)
                 })
+        } else {
+            setError(true)
+            setLoading(false)
         }
     }, [idToken, id])
 

--- a/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/partner/partnerrecruitment/index.js
@@ -1,75 +1,24 @@
-import React, { useEffect, useLayoutEffect } from 'react'
+import React from 'react'
 import { useRouteMatch } from 'react-router'
-import { useDispatch } from 'react-redux'
-import {
-    Switch,
-    Route,
-    Redirect,
-    useLocation,
-    useParams,
-} from 'react-router-dom'
-
-import PageWrapper from 'components/layouts/PageWrapper'
-import * as RecruitmentActions from 'redux/recruitment/actions'
-/*import BasicNavBar from 'components/navbars/BasicNavBar'*/
-import GlobalNavBar from 'components/navbars/GlobalNavBar'
+import { Switch, Route, Redirect } from 'react-router-dom'
 
 import SearchPage from './default'
-// import AdminPage from './admin'
 import DetailPage from './id'
+// TODO rework admin page to allow partners to manage their own teams
+// import AdminPage from './admin'
 
 export default () => {
-    // const dispatch = useDispatch()
-    // const location = useLocation()
     const match = useRouteMatch()
-
-    //console.log(match.url)
-
     return (
         <Switch>
             <Route exact={true} path={`${match.url}`} component={SearchPage} />
-            {/* <Route exact={true} path=`${match.url}/recruitment/admin` component={AdminPage} /> */}
             <Route
                 exact={false}
                 path={`${match.url}/:id`}
                 component={DetailPage}
             />
-            {/* <Route
-                exact={false}
-                path={`${match.url}/admin`}
-                component={AdminPage}
-            /> */}
+            {/* <Route exact={true} path=`${match.url}/recruitment/admin` component={AdminPage} /> */}
             <Redirect to={`${match.url}`} />
         </Switch>
     )
 }
-
-// import React, { useEffect, useRef } from 'react'
-// import FormControl from '@material-ui/core/FormControl'
-// import FormGroup from '@material-ui/core/FormGroup'
-// import FormControlLabel from '@material-ui/core/FormControlLabel'
-// import Checkbox from '@material-ui/core/Checkbox'
-// import { useDispatch, useSelector } from 'react-redux'
-// import PageHeader from 'components/generic/PageHeader'
-// import GradientBox from 'components/generic/GradientBox'
-// import { Grid, Typography } from '@material-ui/core'
-
-// export default () => {
-
-//     return (
-//         <>
-//             {/* button for DEV to swithc between participant / partner view */}
-//             {/* <Button
-//                 onClick={() => setIsPartner(!isPartner)}
-//                 color="primary"
-//                 variant="contained"
-//             >
-//                 Switch between participant / partner view (only for dev)
-//             </Button> */
-//             }
-//             <div className="recruitment">
-//                 <iframe src="/recruitment" width='100%;' height='1500;' frameborder='0'></iframe>
-//             </div>
-//         </>
-//     )
-// }

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -7,7 +7,6 @@ import EventHeroImage from 'components/events/EventHeroImage'
 import Markdown from 'components/generic/Markdown'
 import AnalyticsService from 'services/analytics'
 
-
 import EventTimeline from './EventTimeline'
 import BannerCarousel from 'components/generic/BannerCarousel'
 import GradientBox from 'components/generic/GradientBox'
@@ -154,7 +153,10 @@ export default () => {
                                     <Typography variant="h2">
                                         {event.name}
                                     </Typography>
-                                    <Grid container justify="space-between">
+                                    <Grid
+                                        container
+                                        justifyContent="space-between"
+                                    >
                                         <EventInformation
                                             registration={registration}
                                             event={event}
@@ -177,7 +179,10 @@ export default () => {
                                     <StaggeredListItem>
                                         <Box mt={3} />
                                         <GradientBox color="theme_white" p={3}>
-                                            <Typography variant="button" gutterBottom>
+                                            <Typography
+                                                variant="button"
+                                                gutterBottom
+                                            >
                                                 Event Timeline
                                             </Typography>
                                             <hr className="tw-h-px  tw-bg-gray-500 tw-border-0 tw-dark:bg-gray-900"></hr>

--- a/frontend/src/pages/_home/EventsGrid/index.js
+++ b/frontend/src/pages/_home/EventsGrid/index.js
@@ -10,8 +10,6 @@ import Button from 'components/generic/Button'
 import PageWrapper from 'components/layouts/PageWrapper'
 import { useTranslation } from 'react-i18next'
 
-
-
 export default ({ events, loading = false, title }) => {
     const dispatch = useDispatch()
     const { t } = useTranslation()
@@ -50,8 +48,8 @@ export default ({ events, loading = false, title }) => {
                                         dispatch(
                                             push(
                                                 '/events/' +
-                                                event.slug +
-                                                '/register/',
+                                                    event.slug +
+                                                    '/register/',
                                             ),
                                         )
                                     }
@@ -94,7 +92,7 @@ export default ({ events, loading = false, title }) => {
                         spacing={6}
                         direction="row"
                         alignItems="stretch"
-                        justify="center"
+                        justifyContent="center"
                     >
                         <Grid item xs={12}>
                             <Typography variant="h3" align="center">

--- a/frontend/src/pages/_home/index.js
+++ b/frontend/src/pages/_home/index.js
@@ -25,10 +25,7 @@ import EventsGrid from './EventsGrid'
 
 const useStyles = makeStyles(theme => ({
     root: {
-        background: theme.palette.theme_white.main, //`linear-gradient(to right bottom, ${theme.palette.secondary.contrastText}, ${theme.palette.success.contrastText}, ${theme.palette.primary.contrastText})`,
-
-        //'linear-gradient(to bottom right, blue, pink)',
-        //`linearGradient(${theme.palette.primary}, ${theme.palette.secondary})`,
+        background: theme.palette.theme_white.main,
     },
 }))
 
@@ -117,7 +114,7 @@ export default () => {
                             })}
                         </Typography>
                     </Grid>
-                    <Grid container justify="center" alignItems="center">
+                    <Grid container justifyContent="center" alignItems="center">
                         <Button
                             color="theme_lightgray"
                             variant="outlinedNew"

--- a/frontend/src/pages/_index/EventsGrid/index.js
+++ b/frontend/src/pages/_index/EventsGrid/index.js
@@ -92,7 +92,7 @@ export default ({ events, loading = false, title }) => {
                         spacing={6}
                         direction="row"
                         alignItems="stretch"
-                        justify="center"
+                        justifyContent="center"
                     >
                         <Grid item xs={12}>
                             <Typography variant="h3" align="center">

--- a/frontend/src/pages/_index/IndexPage.js
+++ b/frontend/src/pages/_index/IndexPage.js
@@ -28,11 +28,8 @@ export default () => {
     const [pastEvents] = usePastEvents({ limit: 3 })
     const dispatch = useDispatch()
     const { t } = useTranslation()
-    console.log("activeEvents", activeEvents)
-
 
     return (
-
         <PageWrapper header={() => <GlobalNavBar />} footer={() => <Footer />}>
             <Helmet>
                 <title>{config.PLATFORM_OWNER_NAME}</title>
@@ -99,7 +96,7 @@ export default () => {
                         })}
                     </Typography>
                 </Grid>
-                <Grid container justify="center" alignItems="center">
+                <Grid container justifyContent="center" alignItems="center">
                     <Button
                         color="theme_lightgray"
                         variant="outlinedNew"

--- a/frontend/src/pages/_pricing/index.js
+++ b/frontend/src/pages/_pricing/index.js
@@ -75,7 +75,7 @@ export default () => {
                         <Grid
                             container
                             direction="row"
-                            justify="center"
+                            justifyContent="center"
                             spacing={3}
                         >
                             <PricingCard
@@ -89,7 +89,7 @@ export default () => {
                                 price="Ask: hello@hackjunction.com"
                             />
                             <Divider size={4} />
-                            <Typography variant="body1" justify="center">
+                            <Typography variant="body1" justifyContent="center">
                                 Our expertise of organising hackathons combined
                                 with the power of a highly-customizable platform
                                 for events makes hosting diverse events

--- a/frontend/src/pages/_projects/slug/default/Filters.js
+++ b/frontend/src/pages/_projects/slug/default/Filters.js
@@ -41,7 +41,7 @@ const Filters = ({ event, active = 'by-track', onChange }) => {
     const classes = useStyles()
     console.log('active :>> ', active)
     return (
-        <Grid container justify="center" spacing={1}>
+        <Grid container justifyContent="center" spacing={1}>
             {event.tracksEnabled && event.tracks && (
                 <Grid item xs={12} md={6}>
                     <Box

--- a/frontend/src/redux/dashboard/actions.js
+++ b/frontend/src/redux/dashboard/actions.js
@@ -663,6 +663,7 @@ export const updateAnnotator = slug => async (dispatch, getState) => {
     return error
 }
 
+//TODO use new score criteria to update project scores
 export const updateProjectScores = slug => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 

--- a/frontend/src/redux/recruitment/actions.js
+++ b/frontend/src/redux/recruitment/actions.js
@@ -52,9 +52,8 @@ export const updateEvents = () => (dispatch, getState) => {
     })
 }
 
-export const updateActionHistory = (organisation) => (dispatch, getState) => {
+export const updateActionHistory = organisation => (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
-    console.log("updateActionHistory", organisation)
     dispatch({
         type: ActionTypes.UPDATE_ACTION_HISTORY,
         promise: RecruitmentService.getActionHistory(idToken, organisation),
@@ -69,39 +68,50 @@ export const updateSearchResults = () => (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(state)
     const page = RecruitmentSelectors.page(state)
     const pageSize = RecruitmentSelectors.pageSize(state)
-    const filters = buildFilterArray(RecruitmentSelectors.filters(state))
-    const event = DashboardSelectors.event(state)//will be needed to get event spesific participants. Comes from dashboard state, first recrytool needs to migrated to be component. 
+    const event = DashboardSelectors.event(state) //will be needed to get event spesific participants. Comes from dashboard state, first recrytool needs to migrated to be component.
+    const filters = buildFilterArray(RecruitmentSelectors.filters(state), event)
     dispatch({
         type: ActionTypes.UPDATE_SEARCH_RESULTS,
-        promise: RecruitmentService.search(idToken, filters, page, pageSize, event._id),
+        promise: RecruitmentService.search(
+            idToken,
+            filters,
+            page,
+            pageSize,
+            event._id,
+        ),
         meta: {
             onFailure: e => console.log('Error getting search results', e),
         },
     })
 }
 
-export const sendMessage = (message, userId, organisation) => async (dispatch, getState) => {
-    const idToken = AuthSelectors.getIdToken(getState())
+//TODO rework messaging for recruitment
 
-    const res = await dispatch({
-        type: ActionTypes.UPDATE_ACTION_HISTORY,
-        promise: RecruitmentService.submitAction(
-            'message',
-            idToken,
-            userId,
-            organisation,
-            message,
-        ),
-        meta: {
-            onFailure: e => console.log('Error sending message', e),
-        },
-    })
+// export const sendMessage =
+//     (message, userId, organisation) => async (dispatch, getState) => {
+//         const idToken = AuthSelectors.getIdToken(getState())
 
-    return res
-}
+//         const res = await dispatch({
+//             type: ActionTypes.UPDATE_ACTION_HISTORY,
+//             promise: RecruitmentService.submitAction(
+//                 'message',
+//                 idToken,
+//                 userId,
+//                 organisation,
+//                 eventId,
+//                 message,
+//             ),
+//             meta: {
+//                 onFailure: e => console.log('Error sending message', e),
+//             },
+//         })
+
+//         return res
+//     }
 
 export const toggleFavorite =
-    (userId, isFavorite, organisation) => async (dispatch, getState) => {
+    (userId, isFavorite, organisation, eventId) =>
+    async (dispatch, getState) => {
         const idToken = AuthSelectors.getIdToken(getState())
 
         let res
@@ -114,6 +124,7 @@ export const toggleFavorite =
                     idToken,
                     userId,
                     organisation,
+                    eventId,
                 ),
                 meta: {
                     onFailure: e => console.log('Error adding to favorites', e),
@@ -127,6 +138,7 @@ export const toggleFavorite =
                     idToken,
                     userId,
                     organisation,
+                    eventId,
                 ),
                 meta: {
                     onFailure: e => console.log('Error adding to favorites', e),
@@ -136,12 +148,13 @@ export const toggleFavorite =
         return res
     }
 
-export const updateRecruitersEvent = (partners) => async (dispatch, getState) => {
+export const updateRecruitersEvent = partners => async (dispatch, getState) => {
     dispatch({
         type: ActionTypes.UPDATE_RECRUITERS_EVENT,
         promise: UserProfilesService.getPublicUserProfiles(partners),
         meta: {
-            onFailure: e => console.log('Error getting recruiters for this event', e),
+            onFailure: e =>
+                console.log('Error getting recruiters for this event', e),
         },
     })
 }
@@ -176,8 +189,6 @@ export const addRecruiterEvent =
         return user
     }
 
-
-
 export const deleteRecruiterEvent =
     (userId, event) => async (dispatch, getState) => {
         const idToken = AuthSelectors.getIdToken(getState())
@@ -195,8 +206,6 @@ export const deleteRecruiterEvent =
 
         return user
     }
-
-
 
 /* Admin actions */
 export const updateAdminRecruiters = () => (dispatch, getState) => {
@@ -222,7 +231,6 @@ export const updateAdminSearchResults = query => (dispatch, getState) => {
     })
 }
 
-
 export const adminGrantRecruiterAccess =
     (userId, events, organisation) => async (dispatch, getState) => {
         const idToken = AuthSelectors.getIdToken(getState())
@@ -244,7 +252,7 @@ export const adminGrantRecruiterAccess =
     }
 
 export const adminRevokeRecruiterAccess =
-    (userId) => async (dispatch, getState) => {
+    userId => async (dispatch, getState) => {
         const idToken = AuthSelectors.getIdToken(getState())
 
         const user = await UserProfilesService.deleteRecruitersAdmin(

--- a/frontend/src/services/recruitment.js
+++ b/frontend/src/services/recruitment.js
@@ -24,17 +24,28 @@ RecruitmentService.search = (idToken, filters, page, page_size, eventId) => {
         config(idToken),
     )
 }
-RecruitmentService.getUserProfile = (idToken, userId) => {
-    return _axios.get(`/recruitment/profile/${userId}`, config(idToken))
+RecruitmentService.getUserProfile = (idToken, userId, eventId) => {
+    return _axios.get(
+        `/recruitment/profile/${userId}?event=${eventId}`,
+        config(idToken),
+    )
 }
 
-RecruitmentService.submitAction = (type, idToken, userId, organisation, message) => {
+RecruitmentService.submitAction = (
+    type,
+    idToken,
+    userId,
+    organisation,
+    eventId,
+    message,
+) => {
     return _axios.post(
         '/recruitment/action',
         {
             type,
             user: userId,
             organisation: organisation,
+            event: eventId,
             data: { message: message },
         },
         config(idToken),

--- a/frontend/src/utils/dataModifiers.js
+++ b/frontend/src/utils/dataModifiers.js
@@ -76,3 +76,46 @@ export const getProjectsForTrack = (allProjects, allTeams, trackSlug) => {
     const projectsWithTeam = filterProjectsWithTeam(allProjects, allTeams)
     return projectsWithTeam.filter(project => project.track === trackSlug)
 }
+
+export const flattenObject = (ob, skipArray = [], stringEscapeArray = []) => {
+    //Utility to flatten nested objects for CSV export, used on attendees, projects and recruitment data exports
+    //skipArray is an array of keys to skip and stringEscapeArray is an array of keys to escape if they might have commas or quotes
+    let toReturn = {}
+    for (let i in ob) {
+        if (!ob.hasOwnProperty(i) || skipArray.some(val => val === i)) continue
+
+        if (stringEscapeArray.some(val => val === i)) {
+            toReturn[i] = ob[i].replace(/"/g, '""')
+            continue
+        } else if (typeof ob[i] === 'object' && ob[i] !== null) {
+            // CustomAnswers is a special case for attendee registrations
+            if (i === 'CustomAnswers') {
+                for (let j in ob[i]) {
+                    if (!ob[i].hasOwnProperty(j)) continue
+                    const customAnswerLabel = ob[i][j].label
+                    const customAnswerValue = ob[i][j].value
+                    toReturn[customAnswerLabel] = customAnswerValue.replace(
+                        /"/g,
+                        '""',
+                    )
+                }
+            } else {
+                let flatObject = flattenObject(ob[i])
+                for (let x in flatObject) {
+                    if (!flatObject.hasOwnProperty(x)) continue
+                    if (typeof flatObject[x] === 'string') {
+                        toReturn[i + '.' + x] = flatObject[x].replace(
+                            /"/g,
+                            '""',
+                        )
+                    } else {
+                        toReturn[i + '.' + x] = flatObject[x]
+                    }
+                }
+            }
+        } else {
+            toReturn[i] = ob[i]
+        }
+    }
+    return toReturn
+}

--- a/shared/data/skills-programming-frameworks-tools.json
+++ b/shared/data/skills-programming-frameworks-tools.json
@@ -60,5 +60,9 @@
     "Vue.js",
     "Windows",
     "WordPress",
-    "Xamarin"
+    "Xamarin",
+    "Next.js",
+    "Nuxt.js",
+    "Svelte",
+    "Remix"
 ]

--- a/shared/data/skills-programming-languages.json
+++ b/shared/data/skills-programming-languages.json
@@ -52,5 +52,7 @@
     "VimL",
     "Visual Basic",
     "WebAssembly",
-    "XSLT"
+    "XSLT",
+    "YAML",
+    "Zig"
 ]

--- a/shared/schemas/Recruiter.js
+++ b/shared/schemas/Recruiter.js
@@ -1,12 +1,16 @@
 const mongoose = require('mongoose')
-const { GraphQLObjectType, GraphQLInputObjectType, GraphQLString, GraphQLNonNull } = require('graphql')
-const Misc = require('../constants/misc')
+const {
+    GraphQLObjectType,
+    GraphQLInputObjectType,
+    GraphQLString,
+    GraphQLNonNull,
+} = require('graphql')
 
+// TODO implement recruiter roles and modify naming of recruiters to partners
 const mongooseSchema = new mongoose.Schema({
     recruiterId: {
         type: String,
         required: true,
-
     },
     organization: {
         type: String,
@@ -37,7 +41,6 @@ const EventRecruitersInput = new GraphQLInputObjectType({
         },
     },
 })
-
 
 module.exports = {
     mongoose: mongooseSchema,


### PR DESCRIPTION
# Changes

- Created utility to build recruitment profiles by combining the data from a user registration and their user profile
- Fixed and refactored all recruitment controller methods
- Removed virtuals from recruitment model
- Recruitment profile is now linked to the specific event where the participant is registered
- Added new method getRegistrationsForQuery to registration controller to fetch registrations with a query and pagination
- Removed material-ui button from ActionBar component to use the generic button component
- Refactored Markdown component to use span when wrapping Typography components inside of p or a elements
- Created new flattenObject utility to remove repeated code on attendee and projects tables, and for the export favorite recruitment profiles
- Refactored all instances of Grid with depreciated justify prop, to use new justifyContent instead
- Moved role selector logic, browser notification consent and event data fetch actions from renderDasboard index to _dashboard index
- Added debounce to text search bar used on Organizer events tab
- Added missing key properties to elements resulting from iterations
- Added event logo to render on the partner dashboard
- Re-enabled the recruitment page for partners
- Refactored recruitment related components to make less fetch calls and removed unnecesary redux store calls
- Modified partnerrecruitment/id page to use the RecruitmentService.getUserProfile, instead of UserProfileService methods
- Added eventId to updateSerachResults actions for recruitment redux store
- Modified recruitment helpers to use registration data instead of the user profile properties