### PR TITLE
Hotfix - Complete list of teams not showing for participants

### DIFF
--- a/backend/modules/team/controller.js
+++ b/backend/modules/team/controller.js
@@ -491,32 +491,23 @@ controller.attachUserApplicant = (teams, userId) => {
 
 controller.getTeamsForEvent = async (eventId, userId, page, size, filter) => {
     let eventTeams = []
-    let teamCount = 0
-    if (page && size) {
-        if (filter) {
-            eventTeams = await Team.find({
-                event: eventId,
-                challenge: filter,
-            })
-                .sort({ createdAt: 'desc' })
-                .skip(parseInt(size * page))
-                .limit(parseInt(size))
-            teamCount = await eventTeams.length
-        } else {
-            eventTeams = await Team.find({
-                event: eventId,
-            })
-                .sort({ createdAt: 'desc' })
-                .skip(parseInt(size * page))
-                .limit(parseInt(size))
-            teamCount = await eventTeams.length
-        }
-    } else {
-        eventTeams = await Team.find({
-            event: eventId,
-        }).sort({ createdAt: 'desc' })
-        teamCount = await eventTeams.length
+    const query = { event: eventId }
+
+    if (filter) {
+        query.challenge = filter
     }
+
+    const teamCount = await Team.countDocuments(query)
+
+    if (page && size) {
+        eventTeams = await Team.find(query)
+            .sort({ createdAt: 'desc' })
+            .skip(parseInt(size * page))
+            .limit(parseInt(size))
+    } else {
+        eventTeams = await Team.find(query).sort({ createdAt: 'desc' })
+    }
+
     const teamsWithoutTeamCode = convertToObjectAndStripProperties(eventTeams, [
         'code',
     ])

--- a/frontend/src/components/Team/AdminTeamEdit/index.js
+++ b/frontend/src/components/Team/AdminTeamEdit/index.js
@@ -44,15 +44,6 @@ export default ({
         userProfile: {},
     }
 
-    // TODO add way to remove team members
-    // const onClickRemove = (userId) => {
-    //     console.log("delete", slug, teamData.code, userId)
-    // }
-
-    // const onClickDelete = () => {
-    //     console.log("delete")
-    // }
-
     const handleRemove = useEffect(() => {
         console.log('delete', slug, teamData?.code, teamMemberToRemove)
         setLoading(true)

--- a/frontend/src/components/Team/AdminTeamEdit/index.js
+++ b/frontend/src/components/Team/AdminTeamEdit/index.js
@@ -44,53 +44,62 @@ export default ({
         userProfile: {},
     }
 
-    const handleRemove = useEffect(() => {
-        console.log('delete', slug, teamData?.code, teamMemberToRemove)
-        setLoading(true)
-        dispatch(
-            DashboardActions.organiserRemoveMemberFromTeam(
-                slug,
-                teamData.code,
-                teamMemberToRemove,
-            ),
-        )
-            .then(team => {
-                console.log('removed succesfully.', team)
-                dispatch(OrganiserActions.updateTeamsForEvent(slug))
-            })
-            .then(() => {
-                console.log(
-                    'teams updated',
-                    teamMembersArr.filter(
-                        t => t.profile.userId !== teamMemberToRemove,
-                    ),
-                )
-                setTeamMembersArr(
-                    teamMembersArr.filter(
-                        t => t.profile.userId !== teamMemberToRemove,
-                    ),
-                )
-                dispatch(
-                    SnackbarActions.success(
-                        'removed ' +
-                            teamMemberToRemove +
-                            ' from team ' +
-                            teamData?.code,
-                    ),
-                )
-            })
-            .catch(() => {
-                dispatch(
-                    SnackbarActions.error(
-                        'Something went wrong... please try again.',
-                    ),
-                )
-            })
-            .finally(() => {
-                setTeamMemberToRemove('')
-                setLoading(false)
-            })
-    }, [teamMemberToRemove, slug, teamData?.code, dispatch])
+    // TODO add way to remove team members
+    // const onClickRemove = (userId) => {
+    //     console.log("delete", slug, teamData.code, userId)
+    // }
+
+    // const onClickDelete = () => {
+    //     console.log("delete")
+    // }
+
+    // const handleRemove = useEffect(() => {
+    //     console.log('delete', slug, teamData?.code, teamMemberToRemove)
+    //     setLoading(true)
+    //     dispatch(
+    //         DashboardActions.organiserRemoveMemberFromTeam(
+    //             slug,
+    //             teamData.code,
+    //             teamMemberToRemove,
+    //         ),
+    //     )
+    //         .then(team => {
+    //             console.log('removed succesfully.', team)
+    //             dispatch(OrganiserActions.updateTeamsForEvent(slug))
+    //         })
+    //         .then(() => {
+    //             console.log(
+    //                 'teams updated',
+    //                 teamMembersArr.filter(
+    //                     t => t.profile.userId !== teamMemberToRemove,
+    //                 ),
+    //             )
+    //             setTeamMembersArr(
+    //                 teamMembersArr.filter(
+    //                     t => t.profile.userId !== teamMemberToRemove,
+    //                 ),
+    //             )
+    //             dispatch(
+    //                 SnackbarActions.success(
+    //                     'removed ' +
+    //                         teamMemberToRemove +
+    //                         ' from team ' +
+    //                         teamData?.code,
+    //                 ),
+    //             )
+    //         })
+    //         .catch(() => {
+    //             dispatch(
+    //                 SnackbarActions.error(
+    //                     'Something went wrong... please try again.',
+    //                 ),
+    //             )
+    //         })
+    //         .finally(() => {
+    //             setTeamMemberToRemove('')
+    //             setLoading(false)
+    //         })
+    // }, [teamMemberToRemove, slug, teamData?.code, dispatch])
 
     const classes = junctionStyle()
     return (

--- a/frontend/src/components/Team/TeamHeader/index.js
+++ b/frontend/src/components/Team/TeamHeader/index.js
@@ -21,10 +21,8 @@ export default ({
     let challengeName = null
     let event = useSelector(DashboardSelectors.event)
     if (event === null) {
-        console.log('from organiser')
         event = useSelector(OrganiserSelectors.event)
     }
-    console.log('event', event)
     if (teamChallenge && typeof teamChallenge === 'string') {
         const challengeDetails = event.challenges.find(
             challenge => challenge._id === teamChallenge,

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/team/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/team/index.js
@@ -40,7 +40,6 @@ export default () => {
             component: CandidatesPage,
         })
     }
-    // const hasTeam = useSelector(DashboardSelectors.hasTeam)
     // TODO make tab "my team" and "Team candidates" visible only if user has a team
     return (
         <Container>

--- a/frontend/src/pages/_dashboard/renderDashboard/participant/team/teams/index.js
+++ b/frontend/src/pages/_dashboard/renderDashboard/participant/team/teams/index.js
@@ -19,6 +19,7 @@ import JoinTeamByCode from 'components/Team/JoinTeamByCode'
 import { useTranslation } from 'react-i18next'
 
 export default () => {
+    const numberOfTeamsShown = 30
     const dispatch = useDispatch()
     const event = useSelector(DashboardSelectors.event)
     const { t } = useTranslation()
@@ -36,44 +37,34 @@ export default () => {
 
     const [currentPage, SetCurrentPage] = useState(0)
     const totalResults = useSelector(DashboardSelectors.teamsCount)
-    const totalPages = Math.ceil(totalResults / 25)
+    const totalPages = Math.ceil(totalResults / numberOfTeamsShown)
 
-    const hadleTeamCardClick = useCallback(
-        async teamId => {
-            if (teamId) {
-                setLoading(true)
-                dispatch(DashboardActions.updateSelectedTeam(slug, teamId))
-                    .then(team => {
-                        setSelectedTeam(team)
-                    })
-                    .catch(err => {
-                        console.log(err)
-                    })
-                    .finally(() => {
-                        setLoading(false)
-                    })
-            }
-        },
-        [selectedTeam],
-    )
+    const hadleTeamCardClick = async teamId => {
+        if (teamId) {
+            setLoading(true)
+            dispatch(DashboardActions.updateSelectedTeam(slug, teamId))
+                .then(team => {
+                    setSelectedTeam(team)
+                })
+                .catch(err => {
+                    console.log(err)
+                })
+                .finally(() => {
+                    setLoading(false)
+                })
+        }
+    }
 
     useEffect(() => {
         dispatch(
             DashboardActions.updateTeams(
                 slug,
                 currentPage,
-                25,
+                numberOfTeamsShown,
                 challengeFilter,
             ),
         )
-    }, [
-        currentPage,
-        applying,
-        selected,
-        selectedTeam,
-        joinByCode,
-        challengeFilter,
-    ])
+    }, [currentPage, joinByCode, challengeFilter])
 
     let teamCards = []
     if (challengeFilter !== 'All challenges') {
@@ -180,7 +171,7 @@ export default () => {
                 )}
             {!selected && !applying && (
                 <>
-                    <div className="tw-flex tw-justify-between tw-items-center tw-mb-4">
+                    <div className="tw-flex tw-flex-col md:tw-flex-row tw-justify-between tw-items-center tw-mb-4 tw-gap-2">
                         {!hasTeam ? (
                             <Button
                                 color="outlined_button"
@@ -188,7 +179,6 @@ export default () => {
                                 onClick={() => setJoinByCode(!joinByCode)}
                             >
                                 {t('Join_team_using_code_')}
-                                {/* Join team using a code */}
                             </Button>
                         ) : (
                             <span></span>
@@ -199,7 +189,10 @@ export default () => {
                                 label: challenge.name,
                                 value: challenge._id,
                             }))}
-                            onChange={setChallengeFilter}
+                            onChange={value => {
+                                SetCurrentPage(0)
+                                setChallengeFilter(value)
+                            }}
                         />
                     </div>
                     {joinByCode && (


### PR DESCRIPTION
# Changes

- Fixed team query to paginate results correctly and list all existing teams
- Removed commented code
- Updated pagination frontend for teams to reset page number when the filter changes
- Updated styling of join by code button to stack vertically on smaller viewports